### PR TITLE
Improve data view tables

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -471,6 +471,10 @@ def view_all_data():
     if current_df is None:
         return jsonify([])
     df_temp = current_df.copy()
+    if "Item No." in df_temp.columns and "Item Number" not in df_temp.columns:
+        df_temp.rename(columns={"Item No.": "Item Number"}, inplace=True)
+    if "Item Number" in df_temp.columns:
+        df_temp = df_temp.sort_values("Item Number")
     if "Date" in df_temp.columns and "Description" in df_temp.columns:
         date_index = list(df_temp.columns).index("Date")
         df_temp.insert(
@@ -501,6 +505,10 @@ def search_data():
         results = pd.DataFrame()
     if results.empty:
         return jsonify([])
+    if "Item No." in results.columns and "Item Number" not in results.columns:
+        results.rename(columns={"Item No.": "Item Number"}, inplace=True)
+    if "Item Number" in results.columns:
+        results = results.sort_values("Item Number")
     if "Date" in results.columns and "Description" in results.columns:
         date_index = list(results.columns).index("Date")
         results.insert(

--- a/templates/search.html
+++ b/templates/search.html
@@ -36,7 +36,20 @@
     </div>
     <button type="submit" class="btn btn-primary">Search</button>
   </form>
-  <table id="resultsTable" class="table table-striped"></table>
+  <button id="showAll" class="btn btn-secondary mb-2">Show All</button>
+  <table id="resultsTable" class="table table-striped">
+    <thead>
+      <tr>
+        <th>Item Number</th>
+        <th>Description</th>
+        <th>Price per Unit</th>
+        <th>Unit</th>
+        <th>Invoice No.</th>
+        <th>Date</th>
+        <th>Graph</th>
+      </tr>
+    </thead>
+  </table>
   <script>
     $(document).ready(function(){
       var table = $('#resultsTable').DataTable({
@@ -45,19 +58,28 @@
           data: function(d){
             d.query = $('#query').val();
             d.supply = $('#supply').val();
+          },
           dataSrc: ''
         },
         columns: [
-          { data: 'Date' },
-          { data: 'Graph', orderable:false },
+          { data: 'Item Number' },
           { data: 'Description' },
-          { data: 'Price per Unit' }
-        ]
+          { data: 'Price per Unit' },
+          { data: 'Unit' },
+          { data: 'Invoice No.' },
+          { data: 'Date' },
+          { data: 'Graph', orderable:false }
+        ],
+        pageLength: 10,
+        scrollY: '400px',
+        scrollCollapse: true
       });
       $('#searchForm').on('submit', function(e){
-
         e.preventDefault();
         table.ajax.reload();
+      });
+      $('#showAll').on('click', function(){
+        table.page.len(-1).draw();
       });
     });
   </script>

--- a/templates/view_all.html
+++ b/templates/view_all.html
@@ -13,18 +13,27 @@
       window.location.href = url;
     }
     $(document).ready(function() {
-      $('#resultsTable').DataTable({
-ajax: {
-  url: '{{ url_for("view_all_data") }}?supply={{ supply }}',
-  dataSrc: ''
-},
-
+      var table = $('#resultsTable').DataTable({
+        ajax: {
+          url: '{{ url_for("view_all_data") }}?supply={{ supply }}',
+          dataSrc: ''
+        },
         columns: [
-          { data: 'Date' },
-          { data: 'Graph', orderable:false },
+          { data: 'Item Number' },
           { data: 'Description' },
-          { data: 'Price per Unit' }
-        ]
+          { data: 'Price per Unit' },
+          { data: 'Unit' },
+          { data: 'Invoice No.' },
+          { data: 'Date' },
+          { data: 'Graph', orderable:false }
+        ],
+        pageLength: 10,
+        scrollY: '400px',
+        scrollCollapse: true
+      });
+
+      $('#showAll').on('click', function(){
+        table.page.len(-1).draw();
       });
     });
   </script>
@@ -42,7 +51,20 @@ ajax: {
     </select>
   </div>
   <hr>
-  <table id="resultsTable" class="table table-striped"></table>
+  <button id="showAll" class="btn btn-secondary mb-2">Show All</button>
+  <table id="resultsTable" class="table table-striped">
+    <thead>
+      <tr>
+        <th>Item Number</th>
+        <th>Description</th>
+        <th>Price per Unit</th>
+        <th>Unit</th>
+        <th>Invoice No.</th>
+        <th>Date</th>
+        <th>Graph</th>
+      </tr>
+    </thead>
+  </table>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display all Excel columns plus Graph in View All and Search pages
- add Show All controls to both DataTables
- keep data sorted by item number for both supplies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683fb3fc325c832db18efbae0b4bfd55