### PR TITLE
Improve data view tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Inventory Analyzer
+
+This Flask application loads Excel files and presents inventory data using DataTables.
+
+## Running the Tests
+
+Install dependencies before running the test suite:
+
+```bash
+pip install -r requirements.txt
+```
+
+The requirements include `flask` and `pandas`, which are needed by the tests. After installing them you can run:
+
+```bash
+pytest -q
+```

--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -118,6 +118,15 @@ def preprocess_text_for_search(text):
     """Preprocess text by removing special characters and converting to lowercase."""
     return re.sub(r"[^a-zA-Z0-9\s]", "", str(text)).lower()
 
+
+def normalize_columns(df):
+    """Rename common columns so DataTables receive consistent headers."""
+    if "Item No." in df.columns and "Item Number" not in df.columns:
+        df.rename(columns={"Item No.": "Item Number"}, inplace=True)
+    if "Invoice No." in df.columns and "Invoice No" not in df.columns:
+        df.rename(columns={"Invoice No.": "Invoice No"}, inplace=True)
+    return df
+
 def load_default_file():
     """Load the default Excel file (Supply 1) from the uploads folder on startup."""
     global df
@@ -258,18 +267,7 @@ def view_all():
         flash("⚠ Please ensure the Excel file for the selected supply is available.")
         return redirect(url_for("index"))
     
-    df_temp = current_df.copy()
-    if "Date" in df_temp.columns and "Description" in df_temp.columns:
-        date_index = list(df_temp.columns).index("Date")
-        df_temp.insert(
-            date_index + 1,
-            "Graph",
-            df_temp["Description"].apply(
-                lambda desc: f'<a class="btn btn-secondary" href="{url_for("product_detail", description=desc, supply=supply, ref="view_all")}">Graph</a>'
-            )
-        )
-    table_html = df_temp.to_html(classes="table table-striped", index=False, escape=False)
-    return render_template("view_all.html", table=table_html, supply=supply)
+    return render_template("view_all.html", supply=supply)
 
 @app.route("/search", methods=["GET", "POST"])
 @login_required
@@ -282,34 +280,13 @@ def search():
     if current_df is None:
         flash("⚠ Please ensure the Excel file for the selected supply is available.")
         return redirect(url_for("index"))
-    
-    results = None
-    query = ""
+
+    query = request.args.get("query", "")
     if request.method == "POST":
-        supply = request.form.get("supply", "supply1")
-        current_df = get_current_dataframe(supply)
-        query = request.form.get("query")
-        if not query:
-            flash("⚠ Please enter a search term.")
-        else:
-            preprocessed_query = preprocess_text_for_search(query)
-            keywords = preprocessed_query.split()
-            results = current_df[current_df["Description"].apply(
-                lambda desc: all(keyword in preprocess_text_for_search(desc) for keyword in keywords)
-            )]
-            if results.empty:
-                flash("⚠ No matching results found.")
-    
-    if results is not None and not results.empty:
-        if "Date" in results.columns and "Description" in results.columns:
-            date_index = list(results.columns).index("Date")
-            results.insert(date_index + 1, "Graph", results["Description"].apply(
-                lambda desc: f'<a class="btn btn-secondary" href="{url_for("product_detail", description=desc, supply=supply, ref="search", query=query)}">Graph</a>'
-            ))
-        table_html = results.to_html(classes="table table-striped", index=False, escape=False)
-    else:
-        table_html = None
-    return render_template("search.html", table=table_html, query=query, supply=supply)
+        query = request.form.get("query", "")
+        supply = request.form.get("supply", supply)
+
+    return render_template("search.html", query=query, supply=supply)
 
 @app.route("/graph")
 @login_required
@@ -471,6 +448,9 @@ def view_all_data():
     if current_df is None:
         return jsonify([])
     df_temp = current_df.copy()
+    normalize_columns(df_temp)
+    if "Item Number" in df_temp.columns:
+        df_temp = df_temp.sort_values("Item Number")
     if "Date" in df_temp.columns and "Description" in df_temp.columns:
         date_index = list(df_temp.columns).index("Date")
         df_temp.insert(
@@ -501,6 +481,9 @@ def search_data():
         results = pd.DataFrame()
     if results.empty:
         return jsonify([])
+    normalize_columns(results)
+    if "Item Number" in results.columns:
+        results = results.sort_values("Item Number")
     if "Date" in results.columns and "Description" in results.columns:
         date_index = list(results.columns).index("Date")
         results.insert(

--- a/templates/search.html
+++ b/templates/search.html
@@ -36,7 +36,22 @@
     </div>
     <button type="submit" class="btn btn-primary">Search</button>
   </form>
-  <table id="resultsTable" class="table table-striped"></table>
+  <button id="showAll" class="btn btn-secondary mb-2">Show All</button>
+  <div id="tableWrapper">
+  <table id="resultsTable" class="table table-striped">
+    <thead>
+      <tr>
+        <th>Item Number</th>
+        <th>Description</th>
+        <th>Price per Unit</th>
+        <th>Unit</th>
+        <th>Invoice No.</th>
+        <th>Date</th>
+        <th>Graph</th>
+      </tr>
+    </thead>
+  </table>
+  </div>
   <script>
     $(document).ready(function(){
       var table = $('#resultsTable').DataTable({
@@ -45,19 +60,31 @@
           data: function(d){
             d.query = $('#query').val();
             d.supply = $('#supply').val();
+          },
           dataSrc: ''
         },
         columns: [
-          { data: 'Date' },
-          { data: 'Graph', orderable:false },
+          { data: 'Item Number' },
           { data: 'Description' },
-          { data: 'Price per Unit' }
+          { data: 'Price per Unit' },
+          { data: 'Unit' },
+          { data: 'Invoice No' },
+          { data: 'Date' },
+          { data: 'Graph', orderable:false }
+        ],
+        pageLength: 10,
+        columnDefs: [
+          { targets: [0,2,3,4,5,6], searchable: false },
+          { targets: 6, orderable: false }
         ]
       });
       $('#searchForm').on('submit', function(e){
-
         e.preventDefault();
         table.ajax.reload();
+      });
+      $('#showAll').on('click', function(){
+        table.page.len(-1).draw();
+        $('#tableWrapper').css({'max-height':'400px','overflow-y':'auto'});
       });
     });
   </script>

--- a/templates/view_all.html
+++ b/templates/view_all.html
@@ -13,18 +13,30 @@
       window.location.href = url;
     }
     $(document).ready(function() {
-      $('#resultsTable').DataTable({
-ajax: {
-  url: '{{ url_for("view_all_data") }}?supply={{ supply }}',
-  dataSrc: ''
-},
-
+      var table = $('#resultsTable').DataTable({
+        ajax: {
+          url: '{{ url_for("view_all_data") }}?supply={{ supply }}',
+          dataSrc: ''
+        },
         columns: [
-          { data: 'Date' },
-          { data: 'Graph', orderable:false },
+          { data: 'Item Number' },
           { data: 'Description' },
-          { data: 'Price per Unit' }
+          { data: 'Price per Unit' },
+          { data: 'Unit' },
+          { data: 'Invoice No' },
+          { data: 'Date' },
+          { data: 'Graph', orderable:false }
+        ],
+        pageLength: 10,
+        columnDefs: [
+          { targets: [0,2,3,4,5,6], searchable: false },
+          { targets: 6, orderable: false }
         ]
+      });
+
+      $('#showAll').on('click', function(){
+        table.page.len(-1).draw();
+        $('#tableWrapper').css({'max-height':'400px','overflow-y':'auto'});
       });
     });
   </script>
@@ -42,7 +54,22 @@ ajax: {
     </select>
   </div>
   <hr>
-  <table id="resultsTable" class="table table-striped"></table>
+  <button id="showAll" class="btn btn-secondary mb-2">Show All</button>
+  <div id="tableWrapper">
+  <table id="resultsTable" class="table table-striped">
+    <thead>
+      <tr>
+        <th>Item Number</th>
+        <th>Description</th>
+        <th>Price per Unit</th>
+        <th>Unit</th>
+        <th>Invoice No.</th>
+        <th>Date</th>
+        <th>Graph</th>
+      </tr>
+    </thead>
+  </table>
+  </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display all Excel columns plus Graph in View All and Search pages
- add Show All controls to both DataTables
- keep data sorted by item number for both supplies
- refactor HTML table generation out of Flask views
- add helper for column normalization and update README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_683fb3fc325c832db18efbae0b4bfd55