### PR TITLE
Add async search API

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -33,13 +33,14 @@
     </div>
     <button type="submit" class="btn btn-primary">Search</button>
   </form>
+  <div id="results">
   {% if table %}
     {{ table | safe }}
     <nav aria-label="Page navigation" class="mt-3">
       <ul class="pagination">
         {% if prev_page %}
         <li class="page-item">
-          <a class="page-link" href="{{ url_for('search', supply=supply, page=prev_page) }}">Previous</a>
+          <a class="page-link" href="{{ url_for('search', supply=supply, query=query, page=prev_page) }}">Previous</a>
         </li>
         {% endif %}
         {% if next_page %}
@@ -50,6 +51,36 @@
       </ul>
     </nav>
   {% endif %}
+  </div>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const input = document.getElementById('query');
+  const supply = document.getElementById('supply');
+  const resultsDiv = document.getElementById('results');
+
+  input.addEventListener('input', function() {
+    const val = input.value.trim();
+    const supplyVal = supply.value;
+    fetch(`/api/search?supply=${encodeURIComponent(supplyVal)}&query=${encodeURIComponent(val)}`)
+      .then(r => r.json())
+      .then(data => {
+        const rows = data.data || [];
+        if (rows.length === 0) { resultsDiv.innerHTML = ''; return; }
+        const cols = Object.keys(rows[0]);
+        let html = '<table class="table table-striped"><thead><tr>';
+        cols.forEach(c => { html += `<th>${c}</th>`; });
+        html += '</tr></thead><tbody>';
+        rows.forEach(row => {
+          html += '<tr>';
+          cols.forEach(c => { html += `<td>${row[c] || ''}</td>`; });
+          html += '</tr>';
+        });
+        html += '</tbody></table>';
+        resultsDiv.innerHTML = html;
+      });
+  });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create `/api/search` to serve search results as JSON
- allow `/search` to reuse query on GET when JavaScript is disabled
- add dynamic fetch script to `search.html`

## Testing
- `python -m py_compile ZamoraInventoryApp.py`

------
https://chatgpt.com/codex/tasks/task_e_684097567dac832d83de536e7c439704