### PR TITLE
Add async search API

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -7,11 +7,13 @@ from flask import (
     flash,
     send_file,
     session,
+    jsonify,
 )
 import io
 import matplotlib.pyplot as plt
 from datetime import datetime
 import time
+import json
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 
 # Additional imports for login functionality
@@ -145,6 +147,18 @@ def view_all():
                 lambda desc: f'<a class="btn btn-secondary" href="{url_for("product_detail", description=desc, supply=supply, ref="view_all")}">Graph</a>'
             )
         )
+        # Ensure column order is consistent
+        desired_order = [
+            "Item Number",
+            "Description",
+            "Price per Unit",
+            "Unit",
+            "Invoice No.",
+            "Date",
+            "Graph",
+        ]
+        existing_columns = [c for c in desired_order if c in df_temp.columns]
+        df_temp = df_temp[existing_columns]
 
     page_df = du.paginate_dataframe(df_temp, page, per_page)
     table_html = page_df.to_html(classes="table table-striped", index=False, escape=False)
@@ -174,11 +188,11 @@ def search():
         return redirect(url_for("index"))
     
     results = None
-    query = ""
-    if request.method == "POST":
-        supply = request.form.get("supply", "supply1")
-        current_df = get_current_dataframe(supply)
-        query = request.form.get("query")
+    query = request.form.get("query") if request.method == "POST" else request.args.get("query", "")
+    if request.method == "POST" or query:
+        if request.method == "POST":
+            supply = request.form.get("supply", "supply1")
+            current_df = get_current_dataframe(supply)
         if not query:
             flash("⚠ Please enter a search term.")
         else:
@@ -200,6 +214,17 @@ def search():
                     lambda desc: f'<a class="btn btn-secondary" href="{url_for("product_detail", description=desc, supply=supply, ref="search", query=query)}">Graph</a>'
                 ),
             )
+            desired_order = [
+                "Item Number",
+                "Description",
+                "Price per Unit",
+                "Unit",
+                "Invoice No.",
+                "Date",
+                "Graph",
+            ]
+            existing_cols = [c for c in desired_order if c in results.columns]
+            results = results[existing_cols]
         page_df = du.paginate_dataframe(results, page, per_page)
         table_html = page_df.to_html(classes="table table-striped", index=False, escape=False)
         next_page = page + 1 if len(results) > page * per_page else None
@@ -216,6 +241,53 @@ def search():
         prev_page=prev_page,
         page=page,
     )
+
+
+@app.route("/api/search", methods=["GET"])
+@login_required
+def api_search():
+    supply = request.args.get("supply", "supply1")
+    query = request.args.get("query", "")
+    page = request.args.get("page", 1, type=int)
+    per_page = 20
+
+    current_df = get_current_dataframe(supply)
+    if current_df is None or not query:
+        return jsonify({"table_html": "", "next_page": None, "prev_page": None})
+
+    preprocessed_query = preprocess_text_for_search(query)
+    keywords = preprocessed_query.split()
+    results = current_df[current_df["Description"].apply(
+        lambda desc: all(keyword in preprocess_text_for_search(desc) for keyword in keywords)
+    )]
+
+    if "Date" in results.columns and "Description" in results.columns:
+        date_index = list(results.columns).index("Date")
+        results = results.copy()
+        results.insert(
+            date_index + 1,
+            "Graph",
+            results["Description"].apply(
+                lambda desc: f'<a class="btn btn-secondary" href="{url_for("product_detail", description=desc, supply=supply, ref="search", query=query)}">Graph</a>'
+            ),
+        )
+        desired_order = [
+            "Item Number",
+            "Description",
+            "Price per Unit",
+            "Unit",
+            "Invoice No.",
+            "Date",
+            "Graph",
+        ]
+        existing_cols = [c for c in desired_order if c in results.columns]
+        results = results[existing_cols]
+
+    page_df = du.paginate_dataframe(results, page, per_page)
+    table_html = page_df.to_html(classes="table table-striped", index=False, escape=False)
+    next_page = page + 1 if len(results) > page * per_page else None
+    prev_page = page - 1 if page > 1 else None
+    return jsonify({"table_html": table_html, "next_page": next_page, "prev_page": prev_page})
 
 @app.route("/graph")
 @login_required
@@ -333,7 +405,6 @@ def material_list():
         contractor = request.form.get("contractor")
         address = request.form.get("address")
         order_date = request.form.get("date")
-        import json
         product_data_json = request.form.get("product_data")
         try:
             product_data = json.loads(product_data_json) if product_data_json else []

--- a/templates/search.html
+++ b/templates/search.html
@@ -33,13 +33,14 @@
     </div>
     <button type="submit" class="btn btn-primary">Search</button>
   </form>
+  <div id="results">
   {% if table %}
     {{ table | safe }}
     <nav aria-label="Page navigation" class="mt-3">
       <ul class="pagination">
         {% if prev_page %}
         <li class="page-item">
-          <a class="page-link" href="{{ url_for('search', supply=supply, page=prev_page) }}">Previous</a>
+          <a class="page-link" href="{{ url_for('search', supply=supply, query=query, page=prev_page) }}">Previous</a>
         </li>
         {% endif %}
         {% if next_page %}
@@ -50,6 +51,34 @@
       </ul>
     </nav>
   {% endif %}
+  </div>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const input = document.getElementById('query');
+  const supply = document.getElementById('supply');
+  const resultsDiv = document.getElementById('results');
+
+  input.addEventListener('input', function() {
+    const val = input.value.trim();
+    const supplyVal = supply.value;
+    fetch(`/api/search?supply=${encodeURIComponent(supplyVal)}&query=${encodeURIComponent(val)}`)
+      .then(r => r.json())
+      .then(data => {
+        if (!data.table_html) { resultsDiv.innerHTML = ''; return; }
+        let html = data.table_html;
+        html += '<nav aria-label="Page navigation" class="mt-3"><ul class="pagination">';
+        if (data.prev_page) {
+          html += `<li class="page-item"><a class="page-link" href="?supply=${encodeURIComponent(supplyVal)}&query=${encodeURIComponent(val)}&page=${data.prev_page}">Previous</a></li>`;
+        }
+        if (data.next_page) {
+          html += `<li class="page-item"><a class="page-link" href="?supply=${encodeURIComponent(supplyVal)}&query=${encodeURIComponent(val)}&page=${data.next_page}">Next</a></li>`;
+        }
+        html += '</ul></nav>';
+        resultsDiv.innerHTML = html;
+      });
+  });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create `/api/search` to serve search results as JSON
- allow `/search` to reuse query on GET when JavaScript is disabled
- add dynamic fetch script to `search.html`
- keep the search results columns in the same order as "All Content"

## Testing
- `python -m py_compile ZamoraInventoryApp.py`


------
https://chatgpt.com/codex/tasks/task_e_684097567dac832d83de536e7c439704