### PR TITLE
Add template management features

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -133,6 +133,27 @@ def save_template_to_github(filename: str, content: str) -> bool:
         data["sha"] = sha
     resp = requests.put(api_url, headers=headers, json=data)
     return resp.status_code in (200, 201)
+
+# Helper to delete templates from GitHub
+def delete_template_from_github(filename: str) -> bool:
+    """Delete a template file from GitHub."""
+    token = config.GITHUB_TOKEN
+    repo = config.GITHUB_REPO
+    branch = config.GITHUB_BRANCH
+    if not token or not repo:
+        return False
+
+    api_url = f"https://api.github.com/repos/{repo}/contents/{filename}"
+    headers = {"Authorization": f"Bearer {token}"}
+    get_resp = requests.get(api_url, headers=headers, params={"ref": branch})
+    if get_resp.status_code != 200:
+        return False
+    sha = get_resp.json().get("sha")
+    if not sha:
+        return False
+    data = {"message": f"Delete template {filename}", "sha": sha, "branch": branch}
+    resp = requests.delete(api_url, headers=headers, json=data)
+    return resp.status_code == 200
 # Helper to pull templates from GitHub when not present locally
 def load_templates_from_github():
     """Fetch template JSON files from GitHub and cache them locally."""
@@ -579,12 +600,18 @@ def material_list():
 
     supply1_products = du.df.to_dict("records") if du.df is not None else []
     supply2_products = du.df_supply2.to_dict("records") if du.df_supply2 is not None else []
-    return render_template("material_list.html",
-                           product_list=product_list,
-                           list_option=list_option,
-                           custom_templates=list(custom_templates.keys()),
-                           supply1_products=supply1_products,
-                           supply2_products=supply2_products)
+    template_name = request.args.get("template_name", "")
+    if not template_name and list_option_lower not in ["underground", "rough", "final", "new"]:
+        template_name = list_option
+    return render_template(
+        "material_list.html",
+        product_list=product_list,
+        list_option=list_option,
+        custom_templates=list(custom_templates.keys()),
+        supply1_products=supply1_products,
+        supply2_products=supply2_products,
+        template_name=template_name,
+    )
 
 @app.route("/save_template", methods=["POST"])
 @login_required
@@ -610,6 +637,67 @@ def save_template():
     else:
         flash("Failed to save template to GitHub.", "danger")
     return redirect(url_for("material_list"))
+
+# -------------------------------
+# Template Management Routes
+# -------------------------------
+
+@app.route("/templates")
+@login_required
+def templates_list():
+    load_templates_from_github()
+    templates_dir = os.path.join(config.UPLOAD_FOLDER, "templates")
+    os.makedirs(templates_dir, exist_ok=True)
+    names = [os.path.splitext(f)[0] for f in os.listdir(templates_dir) if f.endswith(".json")]
+    return render_template("templates_list.html", template_names=names)
+
+
+@app.route("/edit_template/<name>")
+@login_required
+def edit_template(name):
+    return redirect(url_for("material_list", list=name, template_name=name))
+
+
+@app.route("/delete_template/<name>", methods=["POST"])
+@login_required
+def delete_template(name):
+    templates_dir = os.path.join(config.UPLOAD_FOLDER, "templates")
+    filepath = os.path.join(templates_dir, f"{name}.json")
+    if os.path.exists(filepath):
+        os.remove(filepath)
+    delete_template_from_github(f"templates/{name}.json")
+    flash("Template deleted.", "info")
+    return redirect(request.referrer or url_for("templates_list"))
+
+
+@app.route("/rename_template/<name>", methods=["POST"])
+@login_required
+def rename_template(name):
+    new_name = request.form.get("new_name")
+    if not new_name:
+        flash("New name required.", "danger")
+        return redirect(request.referrer or url_for("templates_list"))
+    templates_dir = os.path.join(config.UPLOAD_FOLDER, "templates")
+    old_path = os.path.join(templates_dir, f"{name}.json")
+    new_path = os.path.join(templates_dir, f"{new_name}.json")
+    if not os.path.exists(old_path):
+        flash("Template not found.", "danger")
+        return redirect(request.referrer or url_for("templates_list"))
+    try:
+        with open(old_path) as f:
+            content = f.read()
+        os.rename(old_path, new_path)
+    except Exception as e:
+        flash(f"Rename failed: {e}", "danger")
+        return redirect(request.referrer or url_for("templates_list"))
+    success = save_template_to_github(f"templates/{new_name}.json", content)
+    if success:
+        delete_template_from_github(f"templates/{name}.json")
+        flash("Template renamed.", "success")
+    else:
+        flash("Failed to update GitHub.", "danger")
+    load_templates_from_github()
+    return redirect(url_for("templates_list"))
 # -------------------------------
 # Login and Logout Routes
 # -------------------------------

--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -7,6 +7,9 @@
 {% endblock %}
 {% block content %}
 <h1 class="mt-4">Material List</h1>
+{% if template_name %}
+<p class="text-info">Editing template: {{ template_name }}</p>
+{% endif %}
 <a href="{{ url_for('index') }}" class="btn btn-secondary mb-3">Back</a>
 <div class="form-group">
   <label for="listSelector">Choose Template:</label>
@@ -20,6 +23,19 @@
     {% endfor %}
   </select>
 </div>
+{% if custom_templates %}
+<ul class="list-unstyled">
+  {% for name in custom_templates %}
+  <li>
+    {{ name }}
+    <a href="{{ url_for('edit_template', name=name) }}" class="ms-2">Edit</a>
+    <form action="{{ url_for('delete_template', name=name) }}" method="post" class="d-inline" onsubmit="return confirm('Delete template?');">
+      <button type="submit" class="btn btn-link p-0">Delete</button>
+    </form>
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
 <div class="form-group">
   <label for="lookupSupply">Choose Supply for Lookup:</label>
   <select id="lookupSupply" class="form-control">
@@ -75,7 +91,7 @@
   <button type="button" class="btn btn-primary" id="add-item">Add Manual Item</button>
   <button type="button" class="btn btn-success" id="export-pdf">Export to PDF</button>
   <div class="input-group mt-3 mb-3">
-    <input type="text" class="form-control" id="template-name" placeholder="Template name">
+    <input type="text" class="form-control" id="template-name" placeholder="Template name" value="{{ template_name }}">
     <button type="button" class="btn btn-secondary" id="save-template">Save Template</button>
   </div>
   <input type="hidden" name="product_data" id="product_data">

--- a/templates/templates_list.html
+++ b/templates/templates_list.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block title %}Templates{% endblock %}
+{% block content %}
+<h1 class="mt-4">Saved Templates</h1>
+<a href="{{ url_for('material_list') }}" class="btn btn-secondary mb-3">Back</a>
+<table class="table">
+  <thead>
+    <tr><th>Name</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+  {% for name in template_names %}
+    <tr>
+      <td>{{ name }}</td>
+      <td>
+        <a href="{{ url_for('edit_template', name=name) }}" class="btn btn-sm btn-primary">Edit</a>
+        <form action="{{ url_for('rename_template', name=name) }}" method="post" class="d-inline">
+          <input type="text" name="new_name" placeholder="New name" class="form-control d-inline" style="width:auto;display:inline-block;">
+          <button type="submit" class="btn btn-sm btn-warning">Rename</button>
+        </form>
+        <form action="{{ url_for('delete_template', name=name) }}" method="post" class="d-inline" onsubmit="return confirm('Delete template?');">
+          <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add GitHub delete helper and template management routes
- expose template management page and editing links
- allow editing template name in Material List
- create new `templates_list.html` view

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684243fd3eb8832da34bbb356de60a55