### PR TITLE
Add templates links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,7 @@
         <li class="nav-item"><a class="nav-link" href="{{ url_for('search') }}">Search</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('analyze') }}">Analyze</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('material_list') }}">Material List</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('templates_list') }}">Templates</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Logout</a></li>
       </ul>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,5 +6,6 @@
 <a href="{{ url_for('view_all') }}" class="btn btn-secondary">View All Content</a>
 <a href="{{ url_for('search') }}" class="btn btn-secondary">Search Description</a>
 <a href="{{ url_for('analyze') }}" class="btn btn-secondary">Analyze Price Changes</a>
+<a href="{{ url_for('templates_list') }}" class="btn btn-secondary">Templates</a>
 <a href="{{ url_for('material_list') }}" class="btn btn-primary">Material List</a>
 {% endblock %}

--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -23,19 +23,6 @@
     {% endfor %}
   </select>
 </div>
-{% if custom_templates %}
-<ul class="list-unstyled">
-  {% for name in custom_templates %}
-  <li>
-    {{ name }}
-    <a href="{{ url_for('edit_template', name=name) }}" class="ms-2">Edit</a>
-    <form action="{{ url_for('delete_template', name=name) }}" method="post" class="d-inline" onsubmit="return confirm('Delete template?');">
-      <button type="submit" class="btn btn-link p-0">Delete</button>
-    </form>
-  </li>
-  {% endfor %}
-</ul>
-{% endif %}
 <div class="form-group">
   <label for="lookupSupply">Choose Supply for Lookup:</label>
   <select id="lookupSupply" class="form-control">


### PR DESCRIPTION
## Summary
- add `Templates` link to navbar
- add `Templates` button on the home page
- remove inline template management links from material list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684250704acc832db2c20f2fb09bb1cd