### PR TITLE
Fix dollar signs in order summary

### DIFF
--- a/templates/order_summary.html
+++ b/templates/order_summary.html
@@ -50,8 +50,8 @@
           <td>{{ product.quantity }}</td>
           <td>{{ product.description }}</td>
           {% if include_price == "yes" %}
-            <td>{{ product.last_price }}</td>
-            <td>{{ product.total }}</td>
+            <td>{{ "$%.2f"|format(product.last_price) }}</td>
+            <td>{{ "$%.2f"|format(product.total) }}</td>
           {% endif %}
         </tr>
         {% endif %}
@@ -59,9 +59,9 @@
     </tbody>
   </table>
   {% if include_price == "yes" %}
-  <h3>Subtotal: {{ '%.2f'|format(subtotal) }}</h3>
-  <h3>Tax (7%): {{ '%.2f'|format(tax) }}</h3>
-  <h3>Total: {{ '%.2f'|format(total_cost) }}</h3>
+  <h3>Subtotal: {{ "$%.2f"|format(subtotal) }}</h3>
+  <h3>Tax (7%): {{ "$%.2f"|format(tax) }}</h3>
+  <h3>Total: {{ "$%.2f"|format(total_cost) }}</h3>
   {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show dollar signs in the PDF order summary

## Testing
- `pytest -q`
- `pip install pdfkit` *(fails: Could not connect to proxy)*
- attempt to render PDF *(fails: No module named 'pdfkit')*

------
https://chatgpt.com/codex/tasks/task_e_6845bf927a54832da3722b27b73433e4