### PR TITLE
Improve PDF export styling

### DIFF
--- a/templates/order_summary.html
+++ b/templates/order_summary.html
@@ -5,6 +5,12 @@
   <title>Order Summary</title>
   <style>
     /* Add margins to ensure nothing is cut off in the PDF */
+    @page {
+      margin-top: 0.5in;
+      margin-bottom: 0.5in;
+      margin-left: 1in;
+      margin-right: 1in;
+    }
     body {
       font-family: Arial, sans-serif;
       margin: 1in;
@@ -24,6 +30,8 @@
       padding: 8px;
       text-align: left;
     }
+    /* Keep table rows intact across pages */
+    tr { page-break-inside: avoid; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- adjust `@page` margins so top and bottom have a half‑inch space

## Testing
- `python3 -m py_compile ZamoraInventoryApp.py data_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6845dab6f678832db8546be9647f01a8