### PR TITLE
Add PDF download capability

### DIFF
--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -81,6 +81,7 @@
   </table>
   <button type="button" class="btn btn-primary" id="add-item">Add Manual Item</button>
   <button type="button" class="btn btn-success" id="export-pdf">Export to PDF</button>
+  <a href="{{ url_for('download_summary') }}" class="btn btn-info">Download PDF</a>
   <div class="input-group mt-3 mb-3">
     <input type="text" class="form-control" id="template-name" placeholder="Template name" value="{{ template_name }}">
     <button type="button" class="btn btn-secondary" id="save-template">Save Template</button>


### PR DESCRIPTION
## Summary
- store generated PDFs in a BytesIO buffer
- expose new `/download_summary` route for downloading the buffer
- link to new route from material list page

## Testing
- `python -m py_compile ZamoraInventoryApp.py`
- `flake8 ZamoraInventoryApp.py templates/material_list.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ee249978832d8e8cd1ffaca2da53