### PR TITLE
Fix PDF download reliability

### DIFF
--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -81,6 +81,7 @@
   </table>
   <button type="button" class="btn btn-primary" id="add-item">Add Manual Item</button>
   <button type="button" class="btn btn-success" id="export-pdf">Export to PDF</button>
+  <a href="{{ url_for('download_summary') }}" class="btn btn-info">Download PDF</a>
   <div class="input-group mt-3 mb-3">
     <input type="text" class="form-control" id="template-name" placeholder="Template name" value="{{ template_name }}">
     <button type="button" class="btn btn-secondary" id="save-template">Save Template</button>


### PR DESCRIPTION
## Summary
- persist generated PDF to temporary file tied to the session
- fall back to the saved file when downloading the order summary

## Testing
- `python -m py_compile ZamoraInventoryApp.py`
- `flake8 ZamoraInventoryApp.py templates/material_list.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ee249978832d8e8cd1ffaca2da53