### PR TITLE
Fix PDF download reliability

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -19,6 +19,7 @@ import base64
 import requests
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 import os
+import uuid
 
 # Additional imports for login functionality
 from flask_mail import Mail, Message
@@ -52,6 +53,9 @@ app.config["MAIL_DEFAULT_SENDER"] = config.MAIL_DEFAULT_SENDER
 mail = Mail(app)
 serializer = URLSafeTimedSerializer(app.secret_key)
 ALLOWED_EMAILS = config.ALLOWED_EMAILS
+
+# Buffer to temporarily store generated order summary PDFs
+pdf_buffer: io.BytesIO | None = None
 
 # -------------------------------
 # Global Before-Request Handler (Session Timeout)
@@ -531,6 +535,21 @@ def material_list():
         import pdfkit
         try:
             pdf = pdfkit.from_string(rendered, False)
+            global pdf_buffer
+            pdf_buffer = io.BytesIO(pdf)
+            pdf_buffer.seek(0)
+            # Persist PDF to a temporary file for reliability across workers
+            old_path = session.pop("pdf_path", None)
+            if old_path and os.path.exists(old_path):
+                try:
+                    os.remove(old_path)
+                except OSError:
+                    pass
+            pdf_filename = f"order_summary_{uuid.uuid4().hex}.pdf"
+            pdf_path = os.path.join(app.config["UPLOAD_FOLDER"], pdf_filename)
+            with open(pdf_path, "wb") as f:
+                f.write(pdf)
+            session["pdf_path"] = pdf_path
         except Exception as e:
             flash(f"PDF generation failed: {e}", "danger")
             return redirect(url_for("material_list"))
@@ -698,6 +717,37 @@ def rename_template(name):
         flash("Failed to update GitHub.", "danger")
     load_templates_from_github()
     return redirect(url_for("templates_list"))
+
+# -------------------------------
+# PDF Download Route
+# -------------------------------
+
+@app.route("/download_summary")
+@login_required
+def download_summary():
+    """Return the last generated order summary PDF."""
+    global pdf_buffer
+    if pdf_buffer is not None:
+        pdf_buffer.seek(0)
+        return send_file(
+            pdf_buffer,
+            mimetype="application/pdf",
+            as_attachment=True,
+            download_name="order_summary.pdf",
+        )
+
+
+    pdf_path = session.get("pdf_path")
+    if pdf_path and os.path.exists(pdf_path):
+        return send_file(
+            pdf_path,
+            mimetype="application/pdf",
+            as_attachment=True,
+            download_name="order_summary.pdf",
+        )
+
+    flash("No PDF available for download.", "warning")
+    return redirect(url_for("material_list"))
 # -------------------------------
 # Login and Logout Routes
 # -------------------------------

--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -81,6 +81,7 @@
   </table>
   <button type="button" class="btn btn-primary" id="add-item">Add Manual Item</button>
   <button type="button" class="btn btn-success" id="export-pdf">Export to PDF</button>
+  <a href="{{ url_for('download_summary') }}" class="btn btn-info">Download PDF</a>
   <div class="input-group mt-3 mb-3">
     <input type="text" class="form-control" id="template-name" placeholder="Template name" value="{{ template_name }}">
     <button type="button" class="btn btn-secondary" id="save-template">Save Template</button>


### PR DESCRIPTION
## Summary
- simplify PDF storage; use only a file on disk and the in-memory buffer
- drop the session token logic

## Testing
- `python -m py_compile ZamoraInventoryApp.py`
- `flake8 ZamoraInventoryApp.py templates/material_list.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ee249978832d8e8cd1ffaca2da53