### PR TITLE
Return PDF directly after export

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -562,7 +562,14 @@ def material_list():
             flash("Order summary PDF sent to your email.", "success")
         except Exception as e:
             flash(f"Error sending email: {e}", "danger")
-        return redirect(url_for("material_list"))
+
+        pdf_buffer.seek(0)
+        return send_file(
+            pdf_buffer,
+            mimetype="application/pdf",
+            as_attachment=True,
+            download_name="order_summary.pdf",
+        )
     
     # For GET: load predetermined or saved templates
     list_option = request.args.get("list", "underground")


### PR DESCRIPTION
## Summary
- improve the material list export to immediately return the generated PDF instead of redirecting back to the page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684602578eb4832da98034c54e23654a