### PR TITLE
Fix stray text and broken controls on material list page

### DIFF
--- a/static/js/material_list.js
+++ b/static/js/material_list.js
@@ -8,7 +8,6 @@ function recalcRow(row) {
   const qty = parseFloat(row.querySelector('input.quantity').value) || 0;
   row.querySelector('.total').innerText = (lp * qty).toFixed(2);
 }
- main
 
 function attachRowEvents(row) {
   const qty = row.querySelector('input.quantity');
@@ -39,7 +38,6 @@ function attachRowEvents(row) {
   if (rm) {
     rm.addEventListener('click', function () { row.remove(); });
   }
- main
 }
 
 function updatePredeterminedRows() {
@@ -72,7 +70,6 @@ document.addEventListener('DOMContentLoaded', function () {
     handle: '.drag-handle',
     animation: 150
   });
- main
   document.getElementById('add-item').addEventListener('click', function () {
     const table = document.getElementById('material-list');
     const row = table.insertRow();
@@ -82,7 +79,6 @@ document.addEventListener('DOMContentLoaded', function () {
       '<td><input type="number" step="0.01" class="form-control last-price" placeholder="Last price"></td>' +
       '<td class="total">0.00</td>' +
       '<td><span class="btn btn-secondary drag-handle" aria-label="Drag"><i class="bi bi-arrows-move"></i></span> ' +
-        main
       '<button type="button" class="btn btn-danger remove-item" aria-label="Remove"><i class="bi bi-trash"></i></button></td>';
     attachRowEvents(row);
   });

--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -69,10 +69,9 @@
         <td><input type="number" step="0.01" class="form-control last-price" value="{{ product["Last Price"] }}" readonly></td>
         <td class="total">0.00</td>
         <td>
-          <span class="btn btn-secondary drag-handle" aria-label="Drag"><i class="bi bi-arrows-move"></i></span>
-          <button type="button" class="btn btn-danger remove-item" aria-label="Remove"><i class="bi bi-trash"></i></button>
-        </td>
-    main
+            <span class="btn btn-secondary drag-handle" aria-label="Drag"><i class="bi bi-arrows-move"></i></span>
+            <button type="button" class="btn btn-danger remove-item" aria-label="Remove"><i class="bi bi-trash"></i></button>
+          </td>
         </tr>
       {% endfor %}
     </tbody>
@@ -88,7 +87,6 @@
   <input type="hidden" name="product_data" id="product_data">
   <input type="hidden" name="include_price" id="include_price" value="yes">
   </form>
-main
   {% endblock %}
   {% block extra_scripts %}
   <script>
@@ -97,6 +95,5 @@ main
     const baseMaterialUrl = "{{ url_for('material_list') }}";
   </script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
-main
   <script src="{{ url_for('static', filename='js/material_list.js') }}"></script>
   {% endblock %}


### PR DESCRIPTION
## Summary
- remove stray `main` strings from material list template
- clean up material_list.js and restore drag/remove functionality

## Testing
- `python -m py_compile ZamoraInventoryApp.py data_utils.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_6898b15b71a4832d8cfe3b50ae96a63b