### PR TITLE
Refine material list column sizing

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -8,7 +8,22 @@ table.table td, table.table th { text-align: center; }
   word-break: break-word;
 }
 
+#material-table th:first-child,
+#material-table td:first-child {
+  width: 10%;
+}
+
+#material-table th:nth-child(2),
+#material-table td:nth-child(2) {
+  width: 50%;
+}
+
+#material-list .quantity {
+  width: 80px;
+}
+
 #material-list .product {
   white-space: normal;
   overflow-wrap: anywhere;
+  width: 100%;
 }

--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -49,7 +49,7 @@
     </div>
   </div>
   <div class="table-responsive">
-  <table class="table table-striped">
+  <table id="material-table" class="table table-striped">
     <thead>
       <tr>
         <th>Quantity</th>


### PR DESCRIPTION
## Summary
- Narrow material list quantity column and widen description column for clearer item names
- Limit quantity input width to keep focus on long product descriptions

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898f9d039e0832d8b29812b2f65bd47