### PR TITLE
Add support for third supply dataset

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -105,6 +105,7 @@ def login_required(f):
 preprocess_text_for_search = du.preprocess_text_for_search
 load_default_file = du.load_default_file
 load_supply2_file = du.load_supply2_file
+load_supply3_file = du.load_supply3_file
 load_underground_list = du.load_underground_list
 load_rough_list = du.load_rough_list
 load_final_list = du.load_final_list
@@ -191,6 +192,7 @@ def load_templates_from_github():
 # Load data on startup
 load_default_file()
 load_supply2_file()
+load_supply3_file()
 load_underground_list()
 load_rough_list()
 load_final_list()
@@ -630,6 +632,7 @@ def material_list():
 
     supply1_products = du.df.to_dict("records") if du.df is not None else []
     supply2_products = du.df_supply2.to_dict("records") if du.df_supply2 is not None else []
+    supply3_products = du.df_supply3.to_dict("records") if du.df_supply3 is not None else []
     template_name = request.args.get("template_name", "")
     if not template_name and list_option_lower not in ["underground", "rough", "final", "new"]:
         template_name = list_option
@@ -640,6 +643,7 @@ def material_list():
         custom_templates=list(custom_templates.keys()),
         supply1_products=supply1_products,
         supply2_products=supply2_products,
+        supply3_products=supply3_products,
         template_name=template_name,
     )
 

--- a/data_utils.py
+++ b/data_utils.py
@@ -4,11 +4,13 @@ from typing import Optional
 from config import (
     DEFAULT_FILE,
     DEFAULT_SUPPLY2_FILE,
+    DEFAULT_SUPPLY3_FILE,
     UPLOAD_FOLDER,
 )
 # Global DataFrames
 df: Optional[pd.DataFrame] = None
 df_supply2: Optional[pd.DataFrame] = None
+df_supply3: Optional[pd.DataFrame] = None
 df_underground: Optional[pd.DataFrame] = None
 df_rough: Optional[pd.DataFrame] = None
 df_final: Optional[pd.DataFrame] = None
@@ -50,6 +52,21 @@ def load_supply2_file():
             )
 
 
+def load_supply3_file():
+    global df_supply3
+    if os.path.exists(DEFAULT_SUPPLY3_FILE):
+        df_supply3 = pd.read_excel(DEFAULT_SUPPLY3_FILE, engine="openpyxl")
+        if "Date" in df_supply3.columns:
+            df_supply3["Date"] = pd.to_datetime(df_supply3["Date"], errors="coerce")
+        if "Description" in df_supply3.columns:
+            df_supply3["Description"] = df_supply3["Description"].astype(str).str.strip()
+        if "Price per Unit" in df_supply3.columns:
+            df_supply3["Price per Unit"] = pd.to_numeric(
+                df_supply3["Price per Unit"].astype(str).str.replace(',', '', regex=False),
+                errors="coerce",
+            )
+
+
 def load_predetermined_list(filename: str) -> Optional[pd.DataFrame]:
     file_path = os.path.join(UPLOAD_FOLDER, filename)
     if os.path.exists(file_path):
@@ -78,6 +95,8 @@ def load_final_list():
 def get_current_dataframe(supply: str) -> Optional[pd.DataFrame]:
     if supply == "supply2":
         return df_supply2
+    if supply == "supply3":
+        return df_supply3
     return df
 
 


### PR DESCRIPTION
## Summary
- Add `df_supply3` and loader in `data_utils`
- Initialize Supply 3 on app startup and expose its records to templates

## Testing
- `python -m py_compile data_utils.py ZamoraInventoryApp.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0fcaab938832dbcbee9f6e3d09f69