### PR TITLE
Add Lion Plumbing Supply option and supply3 support

### DIFF
--- a/static/js/material_list.js
+++ b/static/js/material_list.js
@@ -19,7 +19,11 @@ function attachRowEvents(row) {
     prod.addEventListener('change', function () {
       const val = this.value.trim().toLowerCase();
       const lookup = document.getElementById('lookupSupply').value;
-      const prodArray = (lookup === 'supply2') ? supply2Products : supply1Products;
+      const prodArray = lookup === 'supply2'
+        ? supply2Products
+        : lookup === 'supply3'
+          ? supply3Products
+          : supply1Products;
       const matches = prodArray.filter(p => (p.Description || p.description || '').toLowerCase() === val);
       if (matches.length) {
         const latest = matches.reduce((a, b) => new Date(b.Date || b.date) > new Date(a.Date || a.date) ? b : a);
@@ -42,7 +46,11 @@ function attachRowEvents(row) {
 
 function updatePredeterminedRows() {
   const lookup = document.getElementById('lookupSupply').value;
-  const prodArray = (lookup === 'supply2') ? supply2Products : supply1Products;
+  const prodArray = lookup === 'supply2'
+    ? supply2Products
+    : lookup === 'supply3'
+      ? supply3Products
+      : supply1Products;
   const rows = document.querySelectorAll('#material-list tr.predetermined');
   rows.forEach(function (r) {
     const desc = r.querySelector('.product').value.trim().toLowerCase();

--- a/templates/analyze.html
+++ b/templates/analyze.html
@@ -9,6 +9,7 @@
     <select name="supply" id="supply" class="form-control">
       <option value="supply1" {% if supply == 'supply1' %}selected{% endif %}>Supply 1</option>
       <option value="supply2" {% if supply == 'supply2' %}selected{% endif %}>Supply 2</option>
+      <option value="supply3" {% if supply == 'supply3' %}selected{% endif %}>Lion Plumbing Supply</option>
     </select>
   </div>
   <div class="form-group">

--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -23,10 +23,16 @@
   <select id="lookupSupply" class="form-control">
     <option value="supply1" selected>Supply 1</option>
     <option value="supply2">Supply 2</option>
+    <option value="supply3">Lion Plumbing Supply</option>
   </select>
 </div>
 <datalist id="supply1List">
   {% for prod in supply1_products %}
+    <option value="{{ prod['Description'] }}">
+  {% endfor %}
+</datalist>
+<datalist id="supply3List">
+  {% for prod in supply3_products %}
     <option value="{{ prod['Description'] }}">
   {% endfor %}
 </datalist>
@@ -89,11 +95,12 @@
   </form>
   {% endblock %}
   {% block extra_scripts %}
-  <script>
-    const supply1Products = {{ supply1_products|tojson }};
-    const supply2Products = {{ supply2_products|tojson }};
-    const baseMaterialUrl = "{{ url_for('material_list') }}";
-  </script>
+    <script>
+      const supply1Products = {{ supply1_products|tojson }};
+      const supply2Products = {{ supply2_products|tojson }};
+      const supply3Products = {{ supply3_products|tojson }};
+      const baseMaterialUrl = "{{ url_for('material_list') }}";
+    </script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
   <script src="{{ url_for('static', filename='js/material_list.js') }}"></script>
   {% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -9,6 +9,7 @@
     <select name="supply" id="supply" class="form-control">
       <option value="supply1" {% if supply == 'supply1' %}selected{% endif %}>Supply 1</option>
       <option value="supply2" {% if supply == 'supply2' %}selected{% endif %}>Supply 2</option>
+      <option value="supply3" {% if supply == 'supply3' %}selected{% endif %}>Lion Plumbing Supply</option>
     </select>
   </div>
     <div class="form-group">

--- a/templates/view_all.html
+++ b/templates/view_all.html
@@ -8,6 +8,7 @@
   <select name="supply" id="supply" class="form-control" onchange="location.href=this.value">
     <option value="{{ url_for('view_all', supply='supply1') }}" {% if supply == 'supply1' %}selected{% endif %}>Supply 1</option>
     <option value="{{ url_for('view_all', supply='supply2') }}" {% if supply == 'supply2' %}selected{% endif %}>Supply 2</option>
+    <option value="{{ url_for('view_all', supply='supply3') }}" {% if supply == 'supply3' %}selected{% endif %}>Lion Plumbing Supply</option>
   </select>
 </div>
 <hr>


### PR DESCRIPTION
## Summary
- add Lion Plumbing Supply option to supply selectors across pages
- extend material list to support supply3 and expose supply3Products constant
- handle supply3 selections in material list JavaScript

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0fe1f2a20832d98f7780985907c7e