### PR TITLE
Add multi-supplier search and combined supplier data

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -97,7 +97,42 @@ def get_current_dataframe(supply: str) -> Optional[pd.DataFrame]:
         return df_supply2
     if supply == "supply3":
         return df_supply3
+    if supply == "all":
+        return get_combined_dataframe()
     return df
+
+
+def get_combined_dataframe() -> Optional[pd.DataFrame]:
+    """Merge all supplier DataFrames on their shared ``Description`` column.
+
+    Returns a DataFrame containing the ``Description`` column and one price
+    column per supplier. Missing DataFrames are ignored. ``None`` is returned
+    if no data is available.
+    """
+
+    frames = []
+    if df is not None:
+        frames.append(
+            df[["Description", "Price per Unit"]]
+            .rename(columns={"Price per Unit": "Supply 1 Price"})
+        )
+    if df_supply2 is not None:
+        frames.append(
+            df_supply2[["Description", "Price per Unit"]]
+            .rename(columns={"Price per Unit": "Supply 2 Price"})
+        )
+    if df_supply3 is not None:
+        frames.append(
+            df_supply3[["Description", "Price per Unit"]]
+            .rename(columns={"Price per Unit": "Supply 3 Price"})
+        )
+    if not frames:
+        return None
+
+    combined = frames[0]
+    for frame in frames[1:]:
+        combined = pd.merge(combined, frame, on="Description", how="outer")
+    return combined
 
 
 def update_list_prices(df_list: Optional[pd.DataFrame]):

--- a/templates/search.html
+++ b/templates/search.html
@@ -10,6 +10,7 @@
       <option value="supply1" {% if supply == 'supply1' %}selected{% endif %}>Supply 1</option>
       <option value="supply2" {% if supply == 'supply2' %}selected{% endif %}>Supply 2</option>
       <option value="supply3" {% if supply == 'supply3' %}selected{% endif %}>Lion Plumbing Supply</option>
+      <option value="all" {% if supply == 'all' %}selected{% endif %}>All Supplies</option>
     </select>
   </div>
     <div class="form-group">
@@ -41,9 +42,14 @@ $(document).ready(function(){
       .then(data => {
         const rows = data.data || [];
         if (rows.length === 0) { resultsDiv.innerHTML = ''; return; }
+        let cols;
+        if (supplyVal === 'all') {
+          cols = ['Description','Supply 1 Price','Supply 2 Price','Supply 3 Price'].filter(c => c in rows[0]);
+        } else {
           const desired = ["Item Number","Description","Price per Unit","Unit","Invoice No.","Date","Graph"];
-          const cols = desired.filter(c => c in rows[0]);
-          let html = '<table id="data-table" class="table table-striped" data-page-length="20"><thead><tr>';
+          cols = desired.filter(c => c in rows[0]);
+        }
+        let html = '<table id="data-table" class="table table-striped" data-page-length="20"><thead><tr>';
         cols.forEach(c => { html += `<th>${c}</th>`; });
         html += '</tr></thead><tbody>';
         rows.forEach(row => {
@@ -51,8 +57,8 @@ $(document).ready(function(){
         });
         html += '</tbody></table>';
         resultsDiv.innerHTML = html;
-          initDataTable('#data-table', 20);
-        });
+        initDataTable('#data-table', 20);
+      });
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- Merge supply data via new `get_combined_dataframe` function and allow requesting all suppliers
- Extend search endpoints and page to handle `supply=all` and show side-by-side prices

## Testing
- `python -m py_compile data_utils.py ZamoraInventoryApp.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a10d8f06d4832d9f66303f7d8ca2f3