### PR TITLE
Prevent duplicate DataTable initialization

### DIFF
--- a/static/js/datatables.js
+++ b/static/js/datatables.js
@@ -1,5 +1,8 @@
 function initDataTable(selector, pageLength) {
   if (window.jQuery && $.fn.DataTable) {
+    if ($.fn.DataTable.isDataTable(selector)) {
+      $(selector).DataTable().destroy();
+    }
     $(selector).DataTable({
       pageLength: pageLength,
       lengthMenu: [[pageLength, 50, 100, -1], [pageLength, 50, 100, 'All']]

--- a/templates/search.html
+++ b/templates/search.html
@@ -31,9 +31,6 @@ $(document).ready(function(){
   const input = document.getElementById('query');
   const supply = document.getElementById('supply');
   const resultsDiv = document.getElementById('results');
-    if ($('#data-table').length) {
-      initDataTable('#data-table', 20);
-    }
   input.addEventListener('input', function() {
     const val = input.value.trim();
     const supplyVal = supply.value;


### PR DESCRIPTION
## Summary
- Guard DataTable initialization against re-use by checking existing instances and destroying them before setup
- Drop redundant DataTable setup in search page to avoid double initialization errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a10edaa86c832db50924e76a127858