### PR TITLE
Add API key guard for OpenAI client in lion matcher

### DIFF
--- a/lion_matcher.py
+++ b/lion_matcher.py
@@ -74,7 +74,12 @@ def match_to_lion(
     lion_df = pd.read_excel(lion_catalog_file)
     
     # Prepare the OpenAI client and compute Lion's embeddings once.
-            client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Missing OpenAI API key. Please set the OPENAI_API_KEY environment variable."
+        )
+    client = OpenAI(api_key=api_key)
     lion_embeddings = np.array(
         [
             d.embedding


### PR DESCRIPTION
## Summary
- Properly indent OpenAI client creation in `match_to_lion`
- Raise a clear `RuntimeError` when `OPENAI_API_KEY` env var is missing

## Testing
- `python -m py_compile lion_matcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68a112eb5b80832d90cc2aae9dbbaa64