### PR TITLE
Load sensitive settings from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Inventory Analyzer
+
+## Required Environment Variables
+
+The application requires the following environment variables to be set:
+
+- `SECRET_KEY`: Secret key used by Flask for session management.
+- `MAIL_USERNAME`: Username for the SMTP server used to send emails.
+- `MAIL_PASSWORD`: Password or app-specific password for the SMTP server.
+
+Ensure these variables are defined in your environment before running the application.
+Optional settings such as `MAIL_SERVER`, `MAIL_PORT`, `MAIL_USE_TLS`, and `MAIL_DEFAULT_SENDER`
+may also be configured with environment variables if needed.

--- a/config.py
+++ b/config.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-SECRET_KEY = os.environ.get("SECRET_KEY", "your_secret_key")
+SECRET_KEY = os.environ["SECRET_KEY"]
 
 UPLOAD_FOLDER = os.path.join(BASE_DIR, "uploads")
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
@@ -23,8 +23,8 @@ DEFAULT_SUPPLY3_FILE = os.path.join(UPLOAD_FOLDER, SUPPLY3_FILENAME)
 MAIL_SERVER = os.environ.get("MAIL_SERVER", "smtp.gmail.com")
 MAIL_PORT = int(os.environ.get("MAIL_PORT", 587))
 MAIL_USE_TLS = os.environ.get("MAIL_USE_TLS", "True").lower() in ["true", "1", "t"]
-MAIL_USERNAME = os.environ.get("MAIL_USERNAME", "aliant.delgado07@gmail.com")
-MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD", "lgco kmqe emqr qdrj")
+MAIL_USERNAME = os.environ["MAIL_USERNAME"]
+MAIL_PASSWORD = os.environ["MAIL_PASSWORD"]
 MAIL_DEFAULT_SENDER = os.environ.get("MAIL_DEFAULT_SENDER", MAIL_USERNAME)
 
 SESSION_PERMANENT = True


### PR DESCRIPTION
## Summary
- Remove default secrets from configuration and require `SECRET_KEY`, `MAIL_USERNAME`, and `MAIL_PASSWORD` to come from the environment.
- Document required environment variables for running the app.

## Testing
- `SECRET_KEY=dummy MAIL_USERNAME=test MAIL_PASSWORD=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a11827f200832d88d58884d80b3bbf