### PR TITLE
Add supply-to-lion conversion route

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -31,6 +31,7 @@
         <li class="nav-item"><a class="nav-link {% if request.endpoint=='search' %}active{% endif %}" href="{{ url_for('search') }}">Search</a></li>
         <li class="nav-item"><a class="nav-link {% if request.endpoint=='analyze' %}active{% endif %}" href="{{ url_for('analyze') }}">Analyze</a></li>
         <li class="nav-item"><a class="nav-link {% if request.endpoint=='material_list' %}active{% endif %}" href="{{ url_for('material_list') }}">Material List</a></li>
+        <li class="nav-item"><a class="nav-link {% if request.endpoint=='convert_to_lion' %}active{% endif %}" href="{{ url_for('convert_to_lion') }}">Convert</a></li>
         <li class="nav-item"><a class="nav-link {% if request.endpoint=='templates_list' %}active{% endif %}" href="{{ url_for('templates_list') }}">Templates</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Logout</a></li>
       </ul>

--- a/templates/convert_to_lion.html
+++ b/templates/convert_to_lion.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block title %}Convert to Lion{% endblock %}
+{% block content %}
+<h1 class="mt-4">Convert to Lion Catalog</h1>
+<form method="post" enctype="multipart/form-data" class="mb-4">
+  <div class="mb-3">
+    <label for="template" class="form-label">Select Saved Template</label>
+    <select class="form-control" id="template" name="template">
+      <option value="">-- Choose Template --</option>
+      {% for name in templates %}
+      <option value="{{ name }}">{{ name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label for="file" class="form-label">Or Upload Supply File</label>
+    <input type="file" class="form-control" id="file" name="file" />
+  </div>
+  <button type="submit" class="btn btn-primary">Convert</button>
+</form>
+{% if table %}
+  <h2>Results</h2>
+  {{ table | safe }}
+  {% if download_filename %}
+    <a href="{{ url_for('download_lion', filename=download_filename) }}" class="btn btn-success mt-3">Download Workbook</a>
+  {% endif %}
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add `/convert_to_lion` route to match supply files or templates against the Lion catalog and generate a workbook of price differences
- Provide template upload/selection UI and show results with download link
- Include navigation link for quick access

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a11a70b0e4832d88988d495a4628ae