### PR TITLE
Handle missing env vars to prevent startup crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Inventory Analyzer
 
-## Required Environment Variables
+## Environment Variables
 
-The application requires the following environment variables to be set:
+The application looks for the following environment variables.  All are
+optional and have reasonable defaults for local development, but you
+should provide real values in production:
 
 - `SECRET_KEY`: Secret key used by Flask for session management.
 - `MAIL_USERNAME`: Username for the SMTP server used to send emails.
 - `MAIL_PASSWORD`: Password or app-specific password for the SMTP server.
 
-Ensure these variables are defined in your environment before running the application.
-Optional settings such as `MAIL_SERVER`, `MAIL_PORT`, `MAIL_USE_TLS`, and `MAIL_DEFAULT_SENDER`
-may also be configured with environment variables if needed.
+Additional settings such as `MAIL_SERVER`, `MAIL_PORT`, `MAIL_USE_TLS`,
+and `MAIL_DEFAULT_SENDER` may also be configured with environment
+variables if needed.

--- a/config.py
+++ b/config.py
@@ -3,7 +3,24 @@ from datetime import timedelta
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-SECRET_KEY = os.environ["SECRET_KEY"]
+"""Application configuration and defaults.
+
+This module previously accessed required environment variables using
+``os.environ["VAR_NAME"]`` which raises a ``KeyError`` when the variable is
+missing.  Deployments that do not define optional settings like
+``SECRET_KEY`` or mail credentials would therefore crash at import time.
+
+To make the application more robust – especially in development or
+platforms where these variables are not provided – the configuration now
+uses ``os.environ.get`` with sensible fallbacks.  This allows the app to
+start with default values while still permitting overrides via
+environment variables.
+"""
+
+# A default value is used if SECRET_KEY isn't specified so the app doesn't
+# crash on start-up.  In production this should be overridden via an
+# environment variable.
+SECRET_KEY = os.environ.get("SECRET_KEY", "change-me")
 
 UPLOAD_FOLDER = os.path.join(BASE_DIR, "uploads")
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
@@ -23,8 +40,9 @@ DEFAULT_SUPPLY3_FILE = os.path.join(UPLOAD_FOLDER, SUPPLY3_FILENAME)
 MAIL_SERVER = os.environ.get("MAIL_SERVER", "smtp.gmail.com")
 MAIL_PORT = int(os.environ.get("MAIL_PORT", 587))
 MAIL_USE_TLS = os.environ.get("MAIL_USE_TLS", "True").lower() in ["true", "1", "t"]
-MAIL_USERNAME = os.environ["MAIL_USERNAME"]
-MAIL_PASSWORD = os.environ["MAIL_PASSWORD"]
+# Mail credentials are optional; default to empty strings if not provided.
+MAIL_USERNAME = os.environ.get("MAIL_USERNAME", "")
+MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD", "")
 MAIL_DEFAULT_SENDER = os.environ.get("MAIL_DEFAULT_SENDER", MAIL_USERNAME)
 
 SESSION_PERMANENT = True


### PR DESCRIPTION
## Summary
- avoid KeyError on missing SECRET_KEY by using default
- make mail credentials optional
- update README to describe optional env vars

## Testing
- `python -m py_compile config.py ZamoraInventoryApp.py`


------
https://chatgpt.com/codex/tasks/task_e_68a11cc26730832d8c9edf2c4e9d9a74