### PR TITLE
Enable template-based conversions

### DIFF
--- a/templates/convert_to_lion.html
+++ b/templates/convert_to_lion.html
@@ -15,6 +15,7 @@
   <div class="mb-3">
     <label for="file" class="form-label">Or Upload Supply File</label>
     <input type="file" class="form-control" id="file" name="file" />
+    <div class="form-text">If neither option is provided, Supply 1 data will be used.</div>
   </div>
   <button type="submit" class="btn btn-primary">Convert</button>
 </form>


### PR DESCRIPTION
## Summary
- Allow conversion using existing GitHub templates or default Supply 1 data
- Safeguard Lion results download with file existence checks
- Clarify convert page that Supply 1 is used when no file or template is provided

## Testing
- `python -m py_compile ZamoraInventoryApp.py`


------
https://chatgpt.com/codex/tasks/task_e_68a124c17d1c832d9b49aa7ec0f47357