### PR TITLE
Fix PDF generation by enabling local CSS access

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -543,6 +543,8 @@ def material_list():
         tax = subtotal * 0.07
         total_cost = subtotal + tax
 
+        os.environ.setdefault("XDG_RUNTIME_DIR", "/tmp")
+        css_path = os.path.join(app.root_path, "static", "css", "order_summary.css")
         rendered = render_template(
             "order_summary.html",
             contractor=contractor,
@@ -553,10 +555,12 @@ def material_list():
             tax=tax,
             total_cost=total_cost,
             include_price=include_price,
+            css_link=f"file://{css_path}",
         )
         import pdfkit
         try:
-            pdf = pdfkit.from_string(rendered, False)
+            options = {"enable-local-file-access": None}
+            pdf = pdfkit.from_string(rendered, False, options=options, css=css_path)
             global pdf_buffer
             pdf_buffer = io.BytesIO(pdf)
             pdf_buffer.seek(0)

--- a/templates/order_summary.html
+++ b/templates/order_summary.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Order Summary</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/order_summary.css') }}">
+  <link rel="stylesheet" href="{{ css_link }}">
 </head>
 <body>
   <h1>Zamora Plumbing Corp</h1>


### PR DESCRIPTION
## Summary
- enable wkhtmltopdf to load local CSS by passing a filesystem path and allowing local file access
- set XDG_RUNTIME_DIR to avoid runtime path warnings

## Testing
- `python -m py_compile ZamoraInventoryApp.py`


------
https://chatgpt.com/codex/tasks/task_e_68a126ba77d8832dab2afb1f5195c32c