### PR TITLE
Enable AI-based conversion of material lists to Lion catalog

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -787,9 +787,31 @@ def convert_to_lion():
     if request.method == "POST":
         uploaded_file = request.files.get("file")
         selected_template = request.form.get("template")
+        product_data_json = request.form.get("product_data")
         supply_path = None
 
-        if uploaded_file and uploaded_file.filename:
+        if product_data_json:
+            try:
+                product_data = json.loads(product_data_json)
+            except Exception as e:
+                flash(f"Invalid product data: {e}", "danger")
+                return redirect(url_for("material_list"))
+            temp_df = pd.DataFrame(product_data)
+            temp_df.rename(
+                columns={
+                    "description": "Description",
+                    "Product Description": "Description",
+                    "quantity": "Quantity",
+                    "last_price": "Price per Unit",
+                    "price": "Price",
+                },
+                inplace=True,
+            )
+            supply_path = os.path.join(
+                app.config["UPLOAD_FOLDER"], f"{uuid.uuid4().hex}_from_material.xlsx"
+            )
+            temp_df.to_excel(supply_path, index=False)
+        elif uploaded_file and uploaded_file.filename:
             filename = secure_filename(uploaded_file.filename)
             supply_path = os.path.join(app.config["UPLOAD_FOLDER"], filename)
             uploaded_file.save(supply_path)

--- a/static/js/material_list.js
+++ b/static/js/material_list.js
@@ -122,6 +122,26 @@ document.addEventListener('DOMContentLoaded', function () {
     document.getElementById('product_data').value = JSON.stringify(productData);
     document.getElementById('material-form').submit();
   });
+  document.getElementById('convert-lion').addEventListener('click', function () {
+    const rows = document.querySelectorAll('#material-list tr');
+    const productData = [];
+    rows.forEach(function (r) {
+      const product = r.querySelector('.product').value;
+      const lastPrice = r.querySelector('input.last-price').value;
+      const quantity = r.querySelector('input.quantity').value;
+      productData.push({ description: product, last_price: lastPrice, quantity: quantity });
+    });
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = '/convert_to_lion';
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'product_data';
+    input.value = JSON.stringify(productData);
+    form.appendChild(input);
+    document.body.appendChild(form);
+    form.submit();
+  });
   document.getElementById('save-template').addEventListener('click', function () {
     const name = document.getElementById('template-name').value.trim();
     if (!name) { alert('Template name required'); return; }

--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -89,6 +89,7 @@
   </table>
   </div>
   <button type="button" class="btn btn-primary" id="add-item">Add Manual Item</button>
+  <button type="button" class="btn btn-warning" id="convert-lion">Convert to Lion</button>
   <button type="button" class="btn btn-success" id="export-pdf">Export to PDF</button>
   <a href="{{ url_for('download_summary') }}" class="btn btn-info">Download PDF</a>
   <div class="input-group mt-3 mb-3">


### PR DESCRIPTION
## Summary
- Add server-side support to convert material list data directly to Lion Plumbing catalog using OpenAI embeddings.
- Provide "Convert to Lion" button on material list page and client-side JavaScript to submit current list for conversion.

## Testing
- `python -m py_compile ZamoraInventoryApp.py lion_matcher.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1296e8c40832d893efc5fd630f644