### PR TITLE
Enhance Lion price matching and PDF export

### DIFF
--- a/templates/convert_to_lion.html
+++ b/templates/convert_to_lion.html
@@ -22,8 +22,14 @@
 {% if table %}
   <h2>Results</h2>
   {{ table | safe }}
+  {% if grand_total is not none %}
+    <p><strong>Total:</strong> {{ "$%.2f"|format(grand_total) }}</p>
+  {% endif %}
   {% if download_filename %}
     <a href="{{ url_for('download_lion', filename=download_filename) }}" class="btn btn-success mt-3">Download Workbook</a>
+  {% endif %}
+  {% if download_pdf %}
+    <a href="{{ url_for('download_lion_pdf', filename=download_pdf) }}" class="btn btn-info mt-3">Download PDF</a>
   {% endif %}
 {% endif %}
 {% endblock %}

--- a/templates/lion_summary.html
+++ b/templates/lion_summary.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Lion Conversion Summary</title>
+  <link rel="stylesheet" href="{{ css_link }}">
+</head>
+<body>
+  <h1>Lion Conversion Summary</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>Quantity</th>
+        <th>Supply Description</th>
+        <th>Lion Description</th>
+        <th>Lion Price</th>
+        <th>Total</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+      <tr>
+        <td>{{ row['Quantity'] }}</td>
+        <td>{{ row['Supply Description'] }}</td>
+        <td>{{ row['Lion Description'] }}</td>
+        {% set lp = row['Lion Price'] %}
+        <td>{% if lp == lp %}{{ "$%.2f"|format(lp) }}{% endif %}</td>
+        {% set tot = row['Total'] %}
+        <td>{% if tot == tot %}{{ "$%.2f"|format(tot) }}{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <h3>Total: {{ "$%.2f"|format(grand_total) }}</h3>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extract Lion price whether catalog uses `Price` or `Price per Unit`
- leave unmatched rows blank and compute per-item totals and grand total
- generate downloadable PDF of Lion conversion results

## Testing
- `python -m py_compile Inventory-analyzer/lion_matcher.py Inventory-analyzer/ZamoraInventoryApp.py`


------
https://chatgpt.com/codex/tasks/task_e_68a12cde73ac832da0a4da41fc86c05c