### PR TITLE
Reorder imports in data_utils

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -1,6 +1,6 @@
-import pandas as pd
 import os
 from typing import Optional
+import pandas as pd
 from config import (
     DEFAULT_FILE,
     DEFAULT_SUPPLY2_FILE,


### PR DESCRIPTION
## Summary
- Reordered imports in `data_utils.py` so that `os`, `Optional`, and `pandas` are imported at the top.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1353fcd3c832d9c41f212fd08e8c7