### PR TITLE
Preserve units and project info when saving material templates

### DIFF
--- a/static/js/material_list.js
+++ b/static/js/material_list.js
@@ -40,7 +40,10 @@ function attachRowEvents(row) {
         const latest = matches.reduce((a, b) => new Date(b.Date || b.date) > new Date(a.Date || a.date) ? b : a);
         row.querySelector('input.last-price').value = latest['Price per Unit'] || latest['price per unit'] || latest.Price || latest.price;
         const unitInput = row.querySelector('input.unit');
-        if (unitInput) { unitInput.value = latest.Unit || latest.unit || ''; }
+        if (unitInput) {
+          const unitVal = latest.Unit || latest.unit;
+          if (unitVal) { unitInput.value = unitVal; }
+        }
         recalcRow(row);
       }
     });
@@ -71,9 +74,15 @@ function updatePredeterminedRows() {
         const db = new Date(b.Date || b.date);
         return db > da ? b : a;
       });
-      r.querySelector('input.last-price').value = latest['Price per Unit'] || latest['price per unit'] || latest.Price || latest.price;
+      const lpInput = r.querySelector('input.last-price');
+      if (lpInput && !lpInput.value) {
+        lpInput.value = latest['Price per Unit'] || latest['price per unit'] || latest.Price || latest.price;
+      }
       const unitInput = r.querySelector('input.unit');
-      if (unitInput) { unitInput.value = latest.Unit || latest.unit || ''; }
+      if (unitInput) {
+        const unitVal = latest.Unit || latest.unit;
+        if (!unitInput.value && unitVal) { unitInput.value = unitVal; }
+      }
       recalcRow(r);
     }
   });
@@ -155,10 +164,17 @@ document.addEventListener('DOMContentLoaded', function () {
       const total = r.querySelector('.total').innerText;
       productData.push({ description: product, unit: unit, last_price: lastPrice, quantity: quantity, total: total });
     });
+    const projectInfo = {
+      contractor: document.getElementById('contractor').value,
+      address: document.getElementById('address').value,
+      date: document.getElementById('date').value
+    };
     fetch('/save_template', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: 'template_name=' + encodeURIComponent(name) + '&product_data=' + encodeURIComponent(JSON.stringify(productData))
+      body: 'template_name=' + encodeURIComponent(name) +
+            '&product_data=' + encodeURIComponent(JSON.stringify(productData)) +
+            '&project_info=' + encodeURIComponent(JSON.stringify(projectInfo))
     }).then(() => location.reload());
   });
 });

--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -47,15 +47,15 @@
     <div class="card-body">
       <div class="form-group">
         <label for="contractor">Contractor</label>
-        <input type="text" id="contractor" name="contractor" class="form-control" placeholder="Enter contractor name">
+        <input type="text" id="contractor" name="contractor" class="form-control" placeholder="Enter contractor name" value="{{ project_info.contractor }}">
       </div>
       <div class="form-group">
         <label for="address">Address</label>
-        <input type="text" id="address" name="address" class="form-control" placeholder="Enter project address">
+        <input type="text" id="address" name="address" class="form-control" placeholder="Enter project address" value="{{ project_info.address }}">
       </div>
       <div class="form-group">
         <label for="date">Date</label>
-        <input type="date" id="date" name="date" class="form-control">
+        <input type="date" id="date" name="date" class="form-control" value="{{ project_info.date }}">
       </div>
     </div>
   </div>
@@ -78,7 +78,7 @@
         <td><input type="text" class="form-control product" value="{{ product['Product Description'] }}" list="supply1List"></td>
         <td><input type="text" class="form-control unit" value="{{ product.get('Unit', product.get('unit', '')) }}"></td>
         <td><input type="number" step="0.01" class="form-control last-price" value="{{ product["Last Price"] }}" readonly></td>
-        <td class="total">0.00</td>
+        <td class="total">{{ product.get('total', '0.00') }}</td>
         <td>
             <span class="btn btn-secondary drag-handle" aria-label="Drag"><i class="bi bi-arrows-move"></i></span>
             <button type="button" class="btn btn-danger remove-item" aria-label="Remove"><i class="bi bi-trash"></i></button>


### PR DESCRIPTION
## Summary
- Save contractor, address, and date along with product data when storing templates
- Preserve unit values when matching Lion products and reload saved units/totals
- Pre-fill project information and totals when loading templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1da3908ec832db6c01b4bd1b574ef