### PR TITLE
Allow login with fixed code

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -999,6 +999,12 @@ def download_summary():
 def login():
     if request.method == "POST":
         email = request.form.get("email")
+        code = request.form.get("code")
+        if email == "zamoraplumbing01@gmail.com" and code == "7199":
+            session["email"] = email
+            session["last_activity"] = time.time()
+            flash("Login successful!", "success")
+            return redirect(url_for("index"))
         if email in ALLOWED_EMAILS:
             token = serializer.dumps(email, salt="email-confirmation")
             login_url = url_for("verify_login", token=token, _external=True)

--- a/templates/login.html
+++ b/templates/login.html
@@ -7,6 +7,10 @@
     <label for="email">Enter your email</label>
     <input type="email" name="email" id="email" class="form-control" required>
   </div>
+  <div class="form-group">
+    <label for="code">Enter code (optional)</label>
+    <input type="text" name="code" id="code" class="form-control">
+  </div>
   <button type="submit" class="btn btn-primary">Send Login Link</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add optional code field to login form
- Allow special email to log in directly with fixed code

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1ede27248832db0da33cf9acce197