### PR TITLE
Persist Zamora Plumbing sessions and extend lifetime

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -77,6 +77,9 @@ def check_session_timeout():
         return
 
     if "email" in session:
+        # Bypass inactivity timeout for the Zamora Plumbing account.
+        if session.get("email") == "zamoraplumbing01@gmail.com":
+            return
         last_activity = session.get("last_activity", time.time())
         if time.time() - last_activity > 18000000:  # 30 minutes inactivity
             session.pop("email", None)
@@ -90,6 +93,9 @@ def check_session_timeout():
 
 def is_logged_in():
     if "email" in session:
+        # Always consider the Zamora Plumbing account as active.
+        if session.get("email") == "zamoraplumbing01@gmail.com":
+            return True
         last_activity = session.get("last_activity", time.time())
         if time.time() - last_activity > 18000000:
             session.pop("email", None)
@@ -1021,6 +1027,7 @@ def verify_login(token):
     try:
         email = serializer.loads(token, salt="email-confirmation", max_age=600)
         session["email"] = email
+        session.permanent = True
         session["last_activity"] = time.time()
         flash("Login successful!", "success")
         return redirect(url_for("index"))

--- a/config.py
+++ b/config.py
@@ -46,7 +46,8 @@ MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD", "")
 MAIL_DEFAULT_SENDER = os.environ.get("MAIL_DEFAULT_SENDER", MAIL_USERNAME)
 
 SESSION_PERMANENT = True
-PERMANENT_SESSION_LIFETIME = timedelta(minutes=30)
+# Extend session lifetime to ensure long-term persistence.
+PERMANENT_SESSION_LIFETIME = timedelta(days=365)
 
 ALLOWED_EXTENSIONS = {"xlsx"}
 


### PR DESCRIPTION
## Summary
- Bypass inactivity timeout for `zamoraplumbing01@gmail.com` in session checks
- Mark sessions permanent on login and extend session lifetime to one year

## Testing
- `python -m py_compile ZamoraInventoryApp.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1eef11748832d998bffaa0272567d