### PR TITLE
Allow code-only login using default email

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -1004,13 +1004,19 @@ def download_summary():
 @app.route("/login", methods=["GET", "POST"])
 def login():
     if request.method == "POST":
-        email = request.form.get("email")
-        code = request.form.get("code")
-        if email == "zamoraplumbing01@gmail.com" and code == "7199":
-            session["email"] = email
-            session["last_activity"] = time.time()
-            flash("Login successful!", "success")
-            return redirect(url_for("index"))
+        email = request.form.get("email", "").strip()
+        code = request.form.get("code", "").strip()
+
+        # Allow direct code-based login without requiring the email field.
+        if code:
+            if code == "7199":
+                session["email"] = "zamoraplumbing01@gmail.com"
+                session["last_activity"] = time.time()
+                flash("Login successful!", "success")
+                return redirect(url_for("index"))
+            flash("Invalid code.", "danger")
+            return redirect(url_for("login"))
+
         if email in ALLOWED_EMAILS:
             token = serializer.dumps(email, salt="email-confirmation")
             login_url = url_for("verify_login", token=token, _external=True)

--- a/templates/login.html
+++ b/templates/login.html
@@ -3,14 +3,14 @@
 {% block content %}
 <h1 class="mt-4">Login</h1>
 <form method="post">
-  <div class="form-group">
-    <label for="email">Enter your email</label>
-    <input type="email" name="email" id="email" class="form-control" required>
-  </div>
-  <div class="form-group">
-    <label for="code">Enter code (optional)</label>
-    <input type="text" name="code" id="code" class="form-control">
-  </div>
-  <button type="submit" class="btn btn-primary">Send Login Link</button>
-</form>
+    <div class="form-group">
+      <label for="email">Enter your email (optional)</label>
+      <input type="email" name="email" id="email" class="form-control">
+    </div>
+    <div class="form-group">
+      <label for="code">Enter code</label>
+      <input type="text" name="code" id="code" class="form-control">
+    </div>
+    <button type="submit" class="btn btn-primary">Log In</button>
+  </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Support logging in with just a code, defaulting to zamoraplumbing01@gmail.com
- Make email optional on the login form and update button text

## Testing
- `python -m py_compile ZamoraInventoryApp.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1f1fa4ef8832daf4848fcb8759149