### PR TITLE
Enable organizing templates in folders

### DIFF
--- a/static/js/material_list.js
+++ b/static/js/material_list.js
@@ -1,7 +1,7 @@
 function changeList(selectedList) {
   const baseUrl = typeof baseMaterialUrl !== 'undefined' ? baseMaterialUrl : '';
   localStorage.setItem('selectedTemplate', selectedList);
-  window.location.href = baseUrl + '?list=' + selectedList;
+  window.location.href = baseUrl + '?list=' + encodeURIComponent(selectedList);
 }
 
 function recalcRow(row) {
@@ -159,8 +159,10 @@ document.addEventListener('DOMContentLoaded', function () {
     form.submit();
   });
   document.getElementById('save-template').addEventListener('click', function () {
-    const name = document.getElementById('template-name').value.trim();
+    const folder = document.getElementById('template-folder').value.trim();
+    let name = document.getElementById('template-name').value.trim();
     if (!name) { alert('Template name required'); return; }
+    if (folder) { name = folder + '/' + name; }
     const rows = document.querySelectorAll('#material-list tr');
     const productData = [];
     rows.forEach(function (r) {

--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -2,8 +2,8 @@
 {% block title %}Material List{% endblock %}
 {% block content %}
 <h1 class="mt-4">Material List</h1>
-{% if template_name %}
-<p class="text-info">Editing template: {{ template_name }}</p>
+{% if full_template_name %}
+<p class="text-info">Editing template: {{ full_template_name }}</p>
 {% endif %}
 <a href="{{ url_for('index') }}" class="btn btn-secondary mb-3">Back</a>
 <div class="form-group">
@@ -14,7 +14,7 @@
     <option value="final" {% if list_option == 'final' %}selected{% endif %}>Final List</option>
     <option value="new" {% if list_option == 'new' %}selected{% endif %}>New List</option>
     {% for name in custom_templates %}
-      <option value="{{ name }}" {% if list_option == name %}selected{% endif %}>{{ name|capitalize }} Template</option>
+      <option value="{{ name }}" {% if list_option == name %}selected{% endif %}>{{ name }} Template</option>
     {% endfor %}
   </select>
 </div>
@@ -93,9 +93,15 @@
   <button type="button" class="btn btn-success" id="export-pdf">Export to PDF</button>
   <a href="{{ url_for('download_summary') }}" class="btn btn-info">Download PDF</a>
   <div class="input-group mt-3 mb-3">
+    <input type="text" class="form-control" id="template-folder" list="folder-options" placeholder="Folder (optional)" value="{{ template_folder }}">
     <input type="text" class="form-control" id="template-name" placeholder="Template name" value="{{ template_name }}">
     <button type="button" class="btn btn-secondary" id="save-template">Save Template</button>
   </div>
+  <datalist id="folder-options">
+    {% for folder in template_folders %}
+      <option value="{{ folder }}">
+    {% endfor %}
+  </datalist>
   <input type="hidden" name="product_data" id="product_data">
   <input type="hidden" name="include_price" id="include_price" value="yes">
   </form>

--- a/templates/templates_list.html
+++ b/templates/templates_list.html
@@ -4,6 +4,13 @@
 <h1 class="mt-4">Saved Templates</h1>
 <a href="{{ url_for('material_list') }}" class="btn btn-secondary mb-3">Back</a>
 
+<form action="{{ url_for('create_template_folder') }}" method="post" class="mb-3">
+  <div class="input-group">
+    <input type="text" name="folder_name" class="form-control" placeholder="New folder name">
+    <button type="submit" class="btn btn-secondary">Create Folder</button>
+  </div>
+</form>
+
 <form method="get" class="row mb-3">
   <div class="col-auto">
     <label for="sort" class="form-label">Sort by</label>
@@ -59,7 +66,7 @@
     <tbody>
     {% for t in template_entries %}
       <tr>
-        <td>{{ t.name }}</td>
+        <td>{{ t.full_name }}</td>
         <td>{{ t.mtime | datetimeformat }}</td>
         <td>
           <a href="{{ url_for('edit_template', name=t.full_name) }}" class="btn btn-sm btn-primary">Edit</a>


### PR DESCRIPTION
## Summary
- Support nested template folders when loading, saving, and listing templates
- Allow creating folders from the Templates page
- Provide UI controls for selecting a folder when saving templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3008b7070832d8b66ffbffe7b0292