### PR TITLE
Default template grouping by folder

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -783,7 +783,7 @@ def templates_list():
     templates_dir = config.TEMPLATE_DATA_DIR
     os.makedirs(templates_dir, exist_ok=True)
     sort_key = request.args.get("sort", "name")
-    group_by = request.args.get("group", "none")
+    group_by = request.args.get("group", "folder")
     entries = []
     folder_set = set()
     for root, dirs, files in os.walk(templates_dir):

--- a/templates/templates_list.html
+++ b/templates/templates_list.html
@@ -22,8 +22,8 @@
   <div class="col-auto">
     <label for="group" class="form-label">Group by</label>
     <select name="group" id="group" class="form-select">
-      <option value="none" {% if group_by=='none' %}selected{% endif %}>None</option>
       <option value="folder" {% if group_by=='folder' %}selected{% endif %}>Folder</option>
+      <option value="none" {% if group_by=='none' %}selected{% endif %}>None</option>
     </select>
   </div>
   <div class="col-auto align-self-end">


### PR DESCRIPTION
## Summary
- Default template listing groups items by folder
- Folder option is now the first choice in the grouping dropdown

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a309d6250c832d88c56d321ed938a5