### PR TITLE
Add supply column and adjust price/unit widths

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -684,6 +684,7 @@ def material_list():
             qty = item.get("quantity", 0)
             unit = item.get("Unit") or item.get("unit", "")
             total = item.get("total") or item.get("Total") or 0
+            supply = item.get("Supply") or item.get("supply", "BPS")
             product_list.append(
                 {
                     "Product Description": desc,
@@ -691,6 +692,7 @@ def material_list():
                     "quantity": qty,
                     "Unit": unit,
                     "total": total,
+                    "Supply": supply,
                 }
             )
     elif list_option_lower == "underground":

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -19,7 +19,12 @@ table.table td, table.table th { text-align: center; }
 
 #material-table th:nth-child(2),
 #material-table td:nth-child(2) {
-  width: 50%;
+  width: 40%;
+}
+
+#material-table th:nth-child(3),
+#material-table td:nth-child(3) {
+  width: 10%;
 }
 
 #material-list .quantity {
@@ -30,4 +35,16 @@ table.table td, table.table th { text-align: center; }
   white-space: normal;
   overflow-wrap: anywhere;
   width: 100%;
+}
+
+#material-list .supply {
+  min-width: 80px;
+}
+
+#material-list .unit {
+  min-width: 90px;
+}
+
+#material-list .last-price {
+  min-width: 120px;
 }

--- a/static/js/material_list.js
+++ b/static/js/material_list.js
@@ -28,6 +28,12 @@ function currentListId() {
     lookup === 'supply2' ? 'supply2List' : 'supply1List';
 }
 
+function currentSupplyCode() {
+  const lookup = document.getElementById('lookupSupply').value;
+  return lookup === 'supply3' ? 'LPS' :
+    lookup === 'supply2' ? 'S2' : 'BPS';
+}
+
 function updateListAttributes() {
   const listId = currentListId();
   document.querySelectorAll('.product').forEach(p => p.setAttribute('list', listId));
@@ -57,6 +63,8 @@ function attachRowEvents(row) {
           const unitVal = latest.Unit || latest.unit;
           if (unitVal) { unitInput.value = unitVal; }
         }
+        const supplyInput = row.querySelector('input.supply');
+        if (supplyInput) { supplyInput.value = currentSupplyCode(); }
         recalcRow(row);
       }
     });
@@ -96,6 +104,8 @@ function updatePredeterminedRows() {
         const unitVal = latest.Unit || latest.unit;
         if (!unitInput.value && unitVal) { unitInput.value = unitVal; }
       }
+      const supplyInput = r.querySelector('input.supply');
+      if (supplyInput) { supplyInput.value = currentSupplyCode(); }
       recalcRow(r);
     }
   });
@@ -128,6 +138,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const row = table.insertRow();
     row.innerHTML = '<td><input type="number" class="form-control quantity" placeholder="Quantity"></td>' +
       '<td><input type="text" class="form-control product" placeholder="Enter product" list="' + currentListId() + '"></td>' +
+      '<td><input type="text" class="form-control supply" value="' + currentSupplyCode() + '" readonly></td>' +
       '<td><input type="text" class="form-control unit" placeholder="Unit"></td>' +
       '<td><input type="number" step="0.01" class="form-control last-price" placeholder="Last price"></td>' +
       '<td class="total">0.00</td>' +
@@ -148,7 +159,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const lastPrice = r.querySelector('input.last-price').value;
       const quantity = r.querySelector('input.quantity').value;
       const total = r.querySelector('.total').innerText;
-      productData.push({ description: product, unit: unit, last_price: lastPrice, quantity: quantity, total: total });
+      const supply = r.querySelector('input.supply').value;
+      productData.push({ description: product, supply: supply, unit: unit, last_price: lastPrice, quantity: quantity, total: total });
     });
     document.getElementById('product_data').value = JSON.stringify(productData);
     document.getElementById('material-form').submit();
@@ -160,7 +172,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const product = r.querySelector('.product').value;
       const lastPrice = r.querySelector('input.last-price').value;
       const quantity = r.querySelector('input.quantity').value;
-      productData.push({ description: product, last_price: lastPrice, quantity: quantity });
+      const supply = r.querySelector('input.supply').value;
+      productData.push({ description: product, supply: supply, last_price: lastPrice, quantity: quantity });
     });
     const form = document.createElement('form');
     form.method = 'POST';
@@ -186,7 +199,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const lastPrice = r.querySelector('input.last-price').value;
       const quantity = r.querySelector('input.quantity').value;
       const total = r.querySelector('.total').innerText;
-      productData.push({ description: product, unit: unit, last_price: lastPrice, quantity: quantity, total: total });
+      const supply = r.querySelector('input.supply').value;
+      productData.push({ description: product, supply: supply, unit: unit, last_price: lastPrice, quantity: quantity, total: total });
     });
     const projectInfo = {
       contractor: document.getElementById('contractor').value,

--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -65,6 +65,7 @@
       <tr>
         <th>Quantity</th>
         <th>Product Description</th>
+        <th>Supply</th>
         <th>Unit</th>
         <th>Last Price</th>
         <th>Total</th>
@@ -76,6 +77,7 @@
       <tr class="predetermined">
         <td><input type="number" class="form-control quantity" value="{{ product.get('quantity', 0) }}"></td>
         <td><input type="text" class="form-control product" value="{{ product['Product Description'] }}" list="supply1List"></td>
+        <td><input type="text" class="form-control supply" value="{{ product.get('Supply', product.get('supply', 'BPS')) }}" readonly></td>
         <td><input type="text" class="form-control unit" value="{{ product.get('Unit', product.get('unit', '')) }}"></td>
         <td><input type="number" step="0.01" class="form-control last-price" value="{{ product["Last Price"] }}" readonly></td>
         <td class="total">{{ product.get('total', '0.00') }}</td>
@@ -88,7 +90,7 @@
     </tbody>
     <tfoot>
       <tr>
-        <td colspan="4" class="text-end"><strong>Grand Total:</strong></td>
+        <td colspan="5" class="text-end"><strong>Grand Total:</strong></td>
         <td id="grand-total">0.00</td>
         <td></td>
       </tr>


### PR DESCRIPTION
## Summary
- add supply code column to material list table and data handling
- widen unit and last price fields for better readability

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a31111628c832db149cc86de6f695b