### PR TITLE
Tighten material list row spacing

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,9 +1,19 @@
 body { padding-top: 4.5rem; }
-table.table td, table.table th { text-align: center; }
+table.table td, table.table th {
+  text-align: center;
+}
 .custom-toast-container { z-index: 1100; }
 .inline-input { width: auto; display: inline-block; }
 
-#material-list td {
+#material-table td,
+#material-table th {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  white-space: nowrap;
+}
+
+#material-list td:nth-child(2),
+#material-table th:nth-child(2) {
   white-space: normal;
   word-break: break-word;
 }


### PR DESCRIPTION
## Summary
- Keep non-description material list cells on a single line
- Allow description column to wrap while reducing table row padding

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a32566be2c832d8235c7c8803e0394