### PR TITLE
Add tax-inclusive total display for templates

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -799,11 +799,29 @@ def templates_list():
                 group = "" if rel_dir == "." else rel_dir
                 name = os.path.splitext(f)[0]
                 full_name = os.path.join(group, name) if group else name
+
+                subtotal = 0.0
+                try:
+                    with open(path, "r") as fh:
+                        content = json.load(fh)
+                    products = content.get("products", []) if isinstance(content, dict) else content
+                    for item in products:
+                        try:
+                            subtotal += float(item.get("total", 0) or float(item.get("last_price", 0)) * float(item.get("quantity", 0)))
+                        except (TypeError, ValueError):
+                            continue
+                except Exception:
+                    subtotal = 0.0
+
+                tax = subtotal * config.TAX_RATE
+                total_with_tax = subtotal + tax
+
                 entries.append({
                     "name": name,
                     "full_name": full_name,
                     "group": group,
                     "mtime": os.path.getmtime(path),
+                    "total_with_tax": total_with_tax,
                 })
     folders = sorted(folder_set)
     if sort_key == "date":

--- a/config.py
+++ b/config.py
@@ -51,6 +51,9 @@ PERMANENT_SESSION_LIFETIME = timedelta(days=365)
 
 ALLOWED_EXTENSIONS = {"xlsx"}
 
+# Sales tax rate applied to template totals
+TAX_RATE = 0.07
+
 ALLOWED_EMAILS = [
     "aliant.delgado@yahoo.com",
     "aliant.delgado17@gmail.com",

--- a/templates/templates_list.html
+++ b/templates/templates_list.html
@@ -36,13 +36,14 @@
     <h3>{{ group or 'Ungrouped' }}</h3>
     <table class="table">
       <thead>
-        <tr><th>Name</th><th>Modified</th><th>Actions</th></tr>
+        <tr><th>Name</th><th>Modified</th><th>Total w/ Tax</th><th>Actions</th></tr>
       </thead>
       <tbody>
         {% for t in templates %}
         <tr>
           <td>{{ t.name }}</td>
           <td>{{ t.mtime | datetimeformat }}</td>
+          <td>{{ "$%.2f"|format(t.total_with_tax) }}</td>
           <td>
             <a href="{{ url_for('edit_template', name=t.full_name) }}" class="btn btn-sm btn-primary">Edit</a>
             <form action="{{ url_for('rename_template', name=t.full_name) }}" method="post" class="d-inline">
@@ -71,13 +72,14 @@
 {% else %}
   <table class="table">
     <thead>
-      <tr><th>Name</th><th>Modified</th><th>Actions</th></tr>
+      <tr><th>Name</th><th>Modified</th><th>Total w/ Tax</th><th>Actions</th></tr>
     </thead>
     <tbody>
     {% for t in template_entries %}
       <tr>
         <td>{{ t.full_name }}</td>
         <td>{{ t.mtime | datetimeformat }}</td>
+        <td>{{ "$%.2f"|format(t.total_with_tax) }}</td>
         <td>
           <a href="{{ url_for('edit_template', name=t.full_name) }}" class="btn btn-sm btn-primary">Edit</a>
           <form action="{{ url_for('rename_template', name=t.full_name) }}" method="post" class="d-inline">


### PR DESCRIPTION
## Summary
- compute subtotal and tax for each template, storing `total_with_tax`
- expose `TAX_RATE` config for easy adjustment
- show formatted "Total w/ Tax" column in template listing

## Testing
- `python -m py_compile ZamoraInventoryApp.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa26f102d0832dbe8846d272673030