### PR TITLE
Enable DataTable on templates list with unsortable action column

### DIFF
--- a/static/js/datatables.js
+++ b/static/js/datatables.js
@@ -3,10 +3,14 @@ function initDataTable(selector, pageLength) {
     if ($.fn.DataTable.isDataTable(selector)) {
       $(selector).DataTable().destroy();
     }
-    $(selector).DataTable({
+    const options = {
       pageLength: pageLength,
       lengthMenu: [[pageLength, 50, 100, -1], [pageLength, 50, 100, 'All']]
-    });
+    };
+    if ($(`${selector} th.no-sort`).length) {
+      options.columnDefs = [{ targets: 'no-sort', orderable: false, searchable: false }];
+    }
+    $(selector).DataTable(options);
   }
 }
 

--- a/templates/templates_list.html
+++ b/templates/templates_list.html
@@ -36,7 +36,7 @@
     <h3>{{ group or 'Ungrouped' }}</h3>
     <table class="table templates-table">
       <thead>
-        <tr><th>Name</th><th>Modified</th><th>Total w/ Tax</th><th>Actions</th></tr>
+        <tr><th>Name</th><th>Modified</th><th>Total w/ Tax</th><th class="no-sort">Actions</th></tr>
       </thead>
       <tbody>
         {% for t in templates %}
@@ -67,9 +67,9 @@
     </table>
   {% endfor %}
 {% else %}
-  <table class="table templates-table">
+  <table id="templates-table" class="table templates-table">
     <thead>
-      <tr><th>Name</th><th>Modified</th><th>Total w/ Tax</th><th>Actions</th></tr>
+      <tr><th>Name</th><th>Modified</th><th>Total w/ Tax</th><th class="no-sort">Actions</th></tr>
     </thead>
     <tbody>
     {% for t in template_entries %}
@@ -179,5 +179,9 @@
   tooltipTriggerList.map(function (tooltipTriggerEl) {
     return new bootstrap.Tooltip(tooltipTriggerEl);
   });
+
+  if (document.getElementById('templates-table')) {
+    initDataTable('#templates-table', 20);
+  }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Assign a unique `templates-table` ID on the templates listing table
- Initialize DataTables for templates with unsortable, unsearchable Actions column
- Expand DataTable helper to honor `no-sort` columns

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa29be38c8832da79d23afdb4a2073