### PR TITLE
Concatenate supply data and add supplier filtering

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -221,6 +221,14 @@ load_rough_list()
 load_final_list()
 load_templates_from_github()
 
+# Mapping between internal supply identifiers and their display names.
+SUPPLY_LABELS = {
+    "supply1": "Supply 1",
+    "supply2": "Supply 2",
+    "supply3": "Lion Plumbing Supply",
+}
+REVERSE_SUPPLY_LABELS = {v: k for k, v in SUPPLY_LABELS.items()}
+
 
 # -------------------------------
 # Routes for Main Functionality (Protected by login_required)
@@ -282,19 +290,27 @@ def search():
     Search the selected supply’s 'Description' column for a query.
     """
     supply = request.args.get("supply", "supply1")
+    if request.method == "POST":
+        supply = request.form.get("supply", supply)
     page = request.args.get("page", 1, type=int)
     per_page = None
-    current_df = get_current_dataframe(supply)
-    if current_df is None:
-        flash("⚠ Please ensure the Excel file for the selected supply is available.")
+
+    combined_df = du.get_combined_dataframe()
+    if combined_df is None:
+        flash("⚠ Please ensure the Excel files for the supplies are available.")
         return redirect(url_for("index"))
-    
+
+    def filter_by_supply(df: pd.DataFrame, supply_key: str) -> pd.DataFrame:
+        if supply_key == "all":
+            return df
+        label = SUPPLY_LABELS.get(supply_key, "Supply 1")
+        return df[df["Supply"] == label]
+
+    current_df = filter_by_supply(combined_df, supply)
+
     results = None
     query = request.form.get("query") if request.method == "POST" else request.args.get("query", "")
     if request.method == "POST" or query:
-        if request.method == "POST":
-            supply = request.form.get("supply", "supply1")
-            current_df = get_current_dataframe(supply)
         if not query:
             flash("⚠ Please enter a search term.")
         else:
@@ -305,48 +321,45 @@ def search():
             )]
             if results.empty:
                 flash("⚠ No matching results found.")
-    
+
     if results is not None and not results.empty:
-        if supply == "all":
-            page_df = results
-            table_html = page_df.to_html(
-                table_id="data-table", classes="table table-striped", index=False, escape=False
-            )
-            table_html = table_html.replace('<table ', '<table data-page-length="20" ')
-            next_page = prev_page = None
+        results = results.copy()
+        if "Date" in results.columns:
+            results["Date"] = results["Date"].dt.strftime("%Y-%m-%d")
+            date_index = list(results.columns).index("Date")
         else:
-            if "Date" in results.columns:
-                results["Date"] = results["Date"].dt.strftime("%Y-%m-%d")
-            if "Date" in results.columns and "Description" in results.columns:
-                date_index = list(results.columns).index("Date")
-                results.insert(
-                    date_index + 1,
-                    "Graph",
-                    results["Description"].apply(
-                        lambda desc: f'<a class="btn btn-secondary" href="{url_for("product_detail", description=desc, supply=supply, ref="search", query=query)}">Graph</a>'
-                    ),
-                )
-                desired_order = [
-                    "Item Number",
-                    "Description",
-                    "Price per Unit",
-                    "Unit",
-                    "Invoice No.",
-                    "Date",
-                    "Graph",
-                ]
-                existing_cols = [c for c in desired_order if c in results.columns]
-                results = results[existing_cols]
-            if per_page:
-                page_df = du.paginate_dataframe(results, page, per_page)
-            else:
-                page_df = results
-            table_html = page_df.to_html(
-                table_id="data-table", classes="table table-striped", index=False, escape=False
+            date_index = 0
+        if "Description" in results.columns:
+            results.insert(
+                date_index + 1,
+                "Graph",
+                results.apply(
+                    lambda row: f'<a class="btn btn-secondary" href="{url_for("product_detail", description=row["Description"], supply=REVERSE_SUPPLY_LABELS.get(row.get("Supply"), "supply1"), ref="search", query=query)}">Graph</a>',
+                    axis=1,
+                ),
             )
-            table_html = table_html.replace('<table ', '<table data-page-length="20" ')
-            next_page = page + 1 if per_page and len(results) > page * per_page else None
-            prev_page = page - 1 if per_page and page > 1 else None
+        desired_order = [
+            "Item Number",
+            "Description",
+            "Price per Unit",
+            "Unit",
+            "Invoice No.",
+            "Date",
+            "Supply",
+            "Graph",
+        ]
+        existing_cols = [c for c in desired_order if c in results.columns]
+        results = results[existing_cols]
+        if per_page:
+            page_df = du.paginate_dataframe(results, page, per_page)
+        else:
+            page_df = results
+        table_html = page_df.to_html(
+            table_id="data-table", classes="table table-striped", index=False, escape=False
+        )
+        table_html = table_html.replace('<table ', '<table data-page-length="20" ')
+        next_page = page + 1 if per_page and len(results) > page * per_page else None
+        prev_page = page - 1 if per_page and page > 1 else None
     else:
         table_html = None
         next_page = prev_page = None
@@ -368,38 +381,52 @@ def api_search():
     query = request.args.get("query", "")
     page = request.args.get("page", 1, type=int)
     per_page = request.args.get("per_page", type=int)
-    current_df = get_current_dataframe(supply)
-    if current_df is None or not query:
+
+    combined_df = du.get_combined_dataframe()
+    if combined_df is None or not query:
         return jsonify({"data": [], "next_page": None, "prev_page": None})
+
+    def filter_by_supply(df: pd.DataFrame, supply_key: str) -> pd.DataFrame:
+        if supply_key == "all":
+            return df
+        label = SUPPLY_LABELS.get(supply_key, "Supply 1")
+        return df[df["Supply"] == label]
+
+    current_df = filter_by_supply(combined_df, supply)
+
     preprocessed_query = preprocess_text_for_search(query)
     keywords = preprocessed_query.split()
     results = current_df[current_df["Description"].apply(
         lambda desc: all(keyword in preprocess_text_for_search(desc) for keyword in keywords)
     )]
 
-    if supply != "all" and "Date" in results.columns and "Description" in results.columns:
+    results = results.copy()
+    if "Date" in results.columns:
+        results["Date"] = results["Date"].dt.strftime("%Y-%m-%d")
         date_index = list(results.columns).index("Date")
-        results = results.copy()
+    else:
+        date_index = 0
+    if "Description" in results.columns:
         results.insert(
             date_index + 1,
             "Graph",
-            results["Description"].apply(
-                lambda desc: f'<a class="btn btn-secondary" href="{url_for("product_detail", description=desc, supply=supply, ref="search", query=query)}">Graph</a>'
+            results.apply(
+                lambda row: f'<a class="btn btn-secondary" href="{url_for("product_detail", description=row["Description"], supply=REVERSE_SUPPLY_LABELS.get(row.get("Supply"), "supply1"), ref="search", query=query)}">Graph</a>',
+                axis=1,
             ),
         )
-        desired_order = [
-            "Item Number",
-            "Description",
-            "Price per Unit",
-            "Unit",
-            "Invoice No.",
-            "Date",
-            "Graph",
-        ]
-        existing_cols = [c for c in desired_order if c in results.columns]
-        results = results[existing_cols]
-    if supply != "all" and "Date" in results.columns:
-        results["Date"] = results["Date"].dt.strftime("%Y-%m-%d")
+    desired_order = [
+        "Item Number",
+        "Description",
+        "Price per Unit",
+        "Unit",
+        "Invoice No.",
+        "Date",
+        "Supply",
+        "Graph",
+    ]
+    existing_cols = [c for c in desired_order if c in results.columns]
+    results = results[existing_cols]
 
     if per_page:
         page_df = du.paginate_dataframe(results, page, per_page)

--- a/data_utils.py
+++ b/data_utils.py
@@ -103,35 +103,29 @@ def get_current_dataframe(supply: str) -> Optional[pd.DataFrame]:
 
 
 def get_combined_dataframe() -> Optional[pd.DataFrame]:
-    """Merge all supplier DataFrames on their shared ``Description`` column.
+    """Concatenate all available supplier DataFrames row-wise.
 
-    Returns a DataFrame containing the ``Description`` column and one price
-    column per supplier. Missing DataFrames are ignored. ``None`` is returned
-    if no data is available.
+    Each row in the returned DataFrame is tagged with a ``Supply`` column
+    identifying its source. ``None`` is returned if no data is available.
     """
 
     frames = []
     if df is not None:
-        frames.append(
-            df[["Description", "Price per Unit"]]
-            .rename(columns={"Price per Unit": "Supply 1 Price"})
-        )
+        temp = df.copy()
+        temp["Supply"] = "Supply 1"
+        frames.append(temp)
     if df_supply2 is not None:
-        frames.append(
-            df_supply2[["Description", "Price per Unit"]]
-            .rename(columns={"Price per Unit": "Supply 2 Price"})
-        )
+        temp = df_supply2.copy()
+        temp["Supply"] = "Supply 2"
+        frames.append(temp)
     if df_supply3 is not None:
-        frames.append(
-            df_supply3[["Description", "Price per Unit"]]
-            .rename(columns={"Price per Unit": "Supply 3 Price"})
-        )
+        temp = df_supply3.copy()
+        temp["Supply"] = "Lion Plumbing Supply"
+        frames.append(temp)
     if not frames:
         return None
 
-    combined = frames[0]
-    for frame in frames[1:]:
-        combined = pd.merge(combined, frame, on="Description", how="outer")
+    combined = pd.concat(frames, ignore_index=True, sort=False)
     return combined
 
 

--- a/templates/search.html
+++ b/templates/search.html
@@ -19,6 +19,15 @@
     </div>
   <button type="submit" class="btn btn-primary">Search</button>
 </form>
+<div id="supply-filter-container" class="mb-3" style="display:none;">
+  <label for="supply-filter">Filter by Supply</label>
+  <select id="supply-filter" class="form-control">
+    <option value="">All</option>
+    <option value="Supply 1">Supply 1</option>
+    <option value="Supply 2">Supply 2</option>
+    <option value="Lion Plumbing Supply">Lion Plumbing Supply</option>
+  </select>
+</div>
 <div id="results">
 {% if table %}
   {{ table | safe }}
@@ -31,32 +40,57 @@ $(document).ready(function(){
   const input = document.getElementById('query');
   const supply = document.getElementById('supply');
   const resultsDiv = document.getElementById('results');
-  input.addEventListener('input', function() {
+  const filterContainer = document.getElementById('supply-filter-container');
+  const filterSelect = document.getElementById('supply-filter');
+
+  function buildTable(rows) {
+    const desired = ["Item Number","Description","Price per Unit","Unit","Invoice No.","Date","Supply","Graph"];
+    const cols = desired.filter(c => c in rows[0]);
+    let html = '<table id="data-table" class="table table-striped" data-page-length="20"><thead><tr>';
+    cols.forEach(c => { html += `<th>${c}</th>`; });
+    html += '</tr></thead><tbody>';
+    rows.forEach(row => {
+      html += '<tr>'; cols.forEach(c => { html += `<td>${row[c] || ''}</td>`; }); html += '</tr>';
+    });
+    html += '</tbody></table>';
+    resultsDiv.innerHTML = html;
+    initDataTable('#data-table', 20);
+    const dt = $('#data-table').DataTable();
+    const supplyIdx = cols.indexOf('Supply');
+    if (supplyIdx >= 0) {
+      filterContainer.style.display = 'block';
+      filterSelect.value = '';
+      filterSelect.onchange = function(){ dt.column(supplyIdx).search(this.value).draw(); };
+    } else {
+      filterContainer.style.display = 'none';
+    }
+  }
+
+  function fetchData(){
     const val = input.value.trim();
     const supplyVal = supply.value;
     fetch(`/api/search?supply=${encodeURIComponent(supplyVal)}&query=${encodeURIComponent(val)}`)
       .then(r => r.json())
       .then(data => {
         const rows = data.data || [];
-        if (rows.length === 0) { resultsDiv.innerHTML = ''; return; }
-        let cols;
-        if (supplyVal === 'all') {
-          cols = ['Description','Supply 1 Price','Supply 2 Price','Supply 3 Price'].filter(c => c in rows[0]);
-        } else {
-          const desired = ["Item Number","Description","Price per Unit","Unit","Invoice No.","Date","Graph"];
-          cols = desired.filter(c => c in rows[0]);
-        }
-        let html = '<table id="data-table" class="table table-striped" data-page-length="20"><thead><tr>';
-        cols.forEach(c => { html += `<th>${c}</th>`; });
-        html += '</tr></thead><tbody>';
-        rows.forEach(row => {
-          html += '<tr>'; cols.forEach(c => { html += `<td>${row[c] || ''}</td>`; }); html += '</tr>';
-        });
-        html += '</tbody></table>';
-        resultsDiv.innerHTML = html;
-        initDataTable('#data-table', 20);
+        if (rows.length === 0) { resultsDiv.innerHTML = ''; filterContainer.style.display = 'none'; return; }
+        buildTable(rows);
       });
-  });
+  }
+
+  input.addEventListener('input', fetchData);
+
+  // Initialize filter for server-rendered results, if any
+  const existingTable = document.getElementById('data-table');
+  if (existingTable) {
+    const dt = $('#data-table').DataTable();
+    const headers = $('#data-table thead th').map(function(){ return $(this).text(); }).get();
+    const supplyIdx = headers.indexOf('Supply');
+    if (supplyIdx >= 0) {
+      filterContainer.style.display = 'block';
+      filterSelect.onchange = function(){ dt.column(supplyIdx).search(this.value).draw(); };
+    }
+  }
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Combine supply spreadsheets row-wise with a `Supply` column identifying the source
- Search endpoints query the concatenated data and optionally filter by supplier
- Search UI shows supplier tags and allows client-side filtering via DataTables

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0e105b8b0832dbfbd47c487c1bcce