### PR TITLE
Add Bond Plumbing Supply support

### DIFF
--- a/ZamoraInventoryApp.py
+++ b/ZamoraInventoryApp.py
@@ -129,6 +129,7 @@ preprocess_text_for_search = du.preprocess_text_for_search
 load_default_file = du.load_default_file
 load_supply2_file = du.load_supply2_file
 load_supply3_file = du.load_supply3_file
+load_supply4_file = du.load_supply4_file
 load_underground_list = du.load_underground_list
 load_rough_list = du.load_rough_list
 load_final_list = du.load_final_list
@@ -216,6 +217,7 @@ def load_templates_from_github():
 load_default_file()
 load_supply2_file()
 load_supply3_file()
+load_supply4_file()
 load_underground_list()
 load_rough_list()
 load_final_list()
@@ -711,6 +713,7 @@ def material_list():
     supply1_products = du.df.to_dict("records") if du.df is not None else []
     supply2_products = du.df_supply2.to_dict("records") if du.df_supply2 is not None else []
     supply3_products = du.df_supply3.to_dict("records") if du.df_supply3 is not None else []
+    supply4_products = du.df_supply4.to_dict("records") if du.df_supply4 is not None else []
     template_name_arg = request.args.get("template_name", "")
     if not template_name_arg and list_option_lower not in ["underground", "rough", "final", "new"]:
         template_name_arg = list_option
@@ -730,6 +733,7 @@ def material_list():
         supply1_products=supply1_products,
         supply2_products=supply2_products,
         supply3_products=supply3_products,
+        supply4_products=supply4_products,
         template_name=template_name,
         template_folder=template_folder,
         full_template_name=full_template_name,

--- a/config.py
+++ b/config.py
@@ -37,6 +37,9 @@ DEFAULT_SUPPLY2_FILE = os.path.join(UPLOAD_FOLDER, SUPPLY2_FILENAME)
 SUPPLY3_FILENAME = "Lion_Bid_Extract.xlsx"
 DEFAULT_SUPPLY3_FILE = os.path.join(UPLOAD_FOLDER, SUPPLY3_FILENAME)
 
+SUPPLY4_FILENAME = "Bond_Bid_Extract.xlsx"
+DEFAULT_SUPPLY4_FILE = os.path.join(UPLOAD_FOLDER, SUPPLY4_FILENAME)
+
 MAIL_SERVER = os.environ.get("MAIL_SERVER", "smtp.gmail.com")
 MAIL_PORT = int(os.environ.get("MAIL_PORT", 587))
 MAIL_USE_TLS = os.environ.get("MAIL_USE_TLS", "True").lower() in ["true", "1", "t"]

--- a/data_utils.py
+++ b/data_utils.py
@@ -5,12 +5,14 @@ from config import (
     DEFAULT_FILE,
     DEFAULT_SUPPLY2_FILE,
     DEFAULT_SUPPLY3_FILE,
+    DEFAULT_SUPPLY4_FILE,
     UPLOAD_FOLDER,
 )
 # Global DataFrames
 df: Optional[pd.DataFrame] = None
 df_supply2: Optional[pd.DataFrame] = None
 df_supply3: Optional[pd.DataFrame] = None
+df_supply4: Optional[pd.DataFrame] = None
 df_underground: Optional[pd.DataFrame] = None
 df_rough: Optional[pd.DataFrame] = None
 df_final: Optional[pd.DataFrame] = None
@@ -67,6 +69,21 @@ def load_supply3_file():
             )
 
 
+def load_supply4_file():
+    global df_supply4
+    if os.path.exists(DEFAULT_SUPPLY4_FILE):
+        df_supply4 = pd.read_excel(DEFAULT_SUPPLY4_FILE, engine="openpyxl")
+        if "Date" in df_supply4.columns:
+            df_supply4["Date"] = pd.to_datetime(df_supply4["Date"], errors="coerce")
+        if "Description" in df_supply4.columns:
+            df_supply4["Description"] = df_supply4["Description"].astype(str).str.strip()
+        if "Price per Unit" in df_supply4.columns:
+            df_supply4["Price per Unit"] = pd.to_numeric(
+                df_supply4["Price per Unit"].astype(str).str.replace(',', '', regex=False),
+                errors="coerce",
+            )
+
+
 def load_predetermined_list(filename: str) -> Optional[pd.DataFrame]:
     file_path = os.path.join(UPLOAD_FOLDER, filename)
     if os.path.exists(file_path):
@@ -97,6 +114,8 @@ def get_current_dataframe(supply: str) -> Optional[pd.DataFrame]:
         return df_supply2
     if supply == "supply3":
         return df_supply3
+    if supply == "supply4":
+        return df_supply4
     if supply == "all":
         return get_combined_dataframe()
     return df
@@ -125,6 +144,11 @@ def get_combined_dataframe() -> Optional[pd.DataFrame]:
         frames.append(
             df_supply3[["Description", "Price per Unit"]]
             .rename(columns={"Price per Unit": "Supply 3 Price"})
+        )
+    if df_supply4 is not None:
+        frames.append(
+            df_supply4[["Description", "Price per Unit"]]
+            .rename(columns={"Price per Unit": "Supply 4 Price"})
         )
     if not frames:
         return None

--- a/static/js/material_list.js
+++ b/static/js/material_list.js
@@ -24,13 +24,15 @@ function updateGrandTotal() {
 
 function currentListId() {
   const lookup = document.getElementById('lookupSupply').value;
-  return lookup === 'supply3' ? 'supply3List' :
+  return lookup === 'supply4' ? 'supply4List' :
+    lookup === 'supply3' ? 'supply3List' :
     lookup === 'supply2' ? 'supply2List' : 'supply1List';
 }
 
 function currentSupplyCode() {
   const lookup = document.getElementById('lookupSupply').value;
-  return lookup === 'supply3' ? 'LPS' :
+  return lookup === 'supply4' ? 'BOND' :
+    lookup === 'supply3' ? 'LPS' :
     lookup === 'supply2' ? 'S2' : 'BPS';
 }
 
@@ -51,6 +53,7 @@ function attachRowEvents(row) {
       const val = this.value.trim().toLowerCase();
       const lookup = document.getElementById('lookupSupply').value;
       const prodArray =
+        lookup === 'supply4' ? supply4Products :
         lookup === 'supply3' ? supply3Products :
         lookup === 'supply2' ? supply2Products :
         supply1Products;
@@ -82,6 +85,7 @@ function attachRowEvents(row) {
 function updatePredeterminedRows() {
   const lookup = document.getElementById('lookupSupply').value;
   const prodArray =
+    lookup === 'supply4' ? supply4Products :
     lookup === 'supply3' ? supply3Products :
     lookup === 'supply2' ? supply2Products :
     supply1Products;

--- a/templates/analyze.html
+++ b/templates/analyze.html
@@ -10,6 +10,7 @@
       <option value="supply1" {% if supply == 'supply1' %}selected{% endif %}>Supply 1</option>
       <option value="supply2" {% if supply == 'supply2' %}selected{% endif %}>Supply 2</option>
       <option value="supply3" {% if supply == 'supply3' %}selected{% endif %}>Lion Plumbing Supply</option>
+      <option value="supply4" {% if supply == 'supply4' %}selected{% endif %}>Bond Plumbing Supply</option>
     </select>
   </div>
   <div class="form-group">

--- a/templates/material_list.html
+++ b/templates/material_list.html
@@ -24,6 +24,7 @@
     <option value="supply1" selected>Supply 1</option>
     <option value="supply2">Supply 2</option>
     <option value="supply3">Lion Plumbing Supply</option>
+    <option value="supply4">Bond Plumbing Supply</option>
   </select>
 </div>
 <datalist id="supply1List">
@@ -38,6 +39,11 @@
 </datalist>
 <datalist id="supply3List">
   {% for prod in supply3_products %}
+    <option value="{{ prod['Description'] }}">
+  {% endfor %}
+</datalist>
+<datalist id="supply4List">
+  {% for prod in supply4_products %}
     <option value="{{ prod['Description'] }}">
   {% endfor %}
 </datalist>
@@ -119,6 +125,7 @@
       const supply1Products = {{ supply1_products|tojson }};
       const supply2Products = {{ supply2_products|tojson }};
       const supply3Products = {{ supply3_products|tojson }};
+      const supply4Products = {{ supply4_products|tojson }};
       const baseMaterialUrl = "{{ url_for('material_list') }}";
     </script>
   <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>

--- a/templates/search.html
+++ b/templates/search.html
@@ -10,6 +10,7 @@
       <option value="supply1" {% if supply == 'supply1' %}selected{% endif %}>Supply 1</option>
       <option value="supply2" {% if supply == 'supply2' %}selected{% endif %}>Supply 2</option>
       <option value="supply3" {% if supply == 'supply3' %}selected{% endif %}>Lion Plumbing Supply</option>
+      <option value="supply4" {% if supply == 'supply4' %}selected{% endif %}>Bond Plumbing Supply</option>
       <option value="all" {% if supply == 'all' %}selected{% endif %}>All Supplies</option>
     </select>
   </div>
@@ -41,7 +42,7 @@ $(document).ready(function(){
         if (rows.length === 0) { resultsDiv.innerHTML = ''; return; }
         let cols;
         if (supplyVal === 'all') {
-          cols = ['Description','Supply 1 Price','Supply 2 Price','Supply 3 Price'].filter(c => c in rows[0]);
+          cols = ['Description','Supply 1 Price','Supply 2 Price','Supply 3 Price','Supply 4 Price'].filter(c => c in rows[0]);
         } else {
           const desired = ["Item Number","Description","Price per Unit","Unit","Invoice No.","Date","Graph"];
           cols = desired.filter(c => c in rows[0]);

--- a/templates/view_all.html
+++ b/templates/view_all.html
@@ -9,6 +9,7 @@
     <option value="{{ url_for('view_all', supply='supply1') }}" {% if supply == 'supply1' %}selected{% endif %}>Supply 1</option>
     <option value="{{ url_for('view_all', supply='supply2') }}" {% if supply == 'supply2' %}selected{% endif %}>Supply 2</option>
     <option value="{{ url_for('view_all', supply='supply3') }}" {% if supply == 'supply3' %}selected{% endif %}>Lion Plumbing Supply</option>
+    <option value="{{ url_for('view_all', supply='supply4') }}" {% if supply == 'supply4' %}selected{% endif %}>Bond Plumbing Supply</option>
   </select>
 </div>
 <hr>


### PR DESCRIPTION
## Summary
- load Bond Plumbing Supply spreadsheet and integrate as Supply 4
- expose Bond Plumbing Supply across search, view, analyze, and material list screens
- handle Bond Plumbing Supply data in material list JavaScript

## Testing
- `python -m py_compile ZamoraInventoryApp.py config.py data_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5c2827f38832d92fb5eb5d986b8f0